### PR TITLE
ncurses: forms reworked to be dynamically resizable 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,9 +10,11 @@ v2.?.? - ??.??.????
     - Change: reworked files and dirs handling
     - Change: show cmd is copy-paste friendly now
     - Change: escape key action for dropdown windows;
+    - Change: group search ("g:" for show all groups)
     - Bugfix: incorrect SVG map export, sorted by group
     - Bugfix: cold USB attach was broken if USB was previously disabled
-    and VM is not running at least once
+            and VM is not running at least once
+    - Bugfix: form resizing:)
 
 v2.6.0 - 19.03.2021
 ------------------------

--- a/src/nm_9p_share.c
+++ b/src/nm_9p_share.c
@@ -3,17 +3,11 @@
 #include <nm_utils.h>
 #include <nm_string.h>
 #include <nm_window.h>
+#include <nm_menu.h>
 #include <nm_database.h>
 #include <nm_cfg_file.h>
 #include <nm_vm_control.h>
 #include <nm_9p_share.h>
-
-static const char NM_9P_SET_MODE_SQL[] =
-    "UPDATE vms SET fs9p_enable='%s' WHERE name='%s'";
-static const char NM_9P_SET_PATH_SQL[] =
-    "UPDATE vms SET fs9p_path='%s' WHERE name='%s'";
-static const char NM_9P_SET_NAME_SQL[] =
-    "UPDATE vms SET fs9p_name='%s' WHERE name='%s'";
 
 typedef struct {
     nm_str_t mode;
@@ -23,65 +17,81 @@ typedef struct {
 
 #define NM_INIT_9P_DATA (nm_9p_data_t) { NM_INIT_STR, NM_INIT_STR, NM_INIT_STR }
 
-enum {
-    NM_FLD_9PMODE = 0,
-    NM_FLD_9PPATH,
-    NM_FLD_9PNAME,
-    NM_FLD_COUNT
-};
+static const char NM_9P_SET_MODE_SQL[] =
+    "UPDATE vms SET fs9p_enable='%s' WHERE name='%s'";
+static const char NM_9P_SET_PATH_SQL[] =
+    "UPDATE vms SET fs9p_path='%s' WHERE name='%s'";
+static const char NM_9P_SET_NAME_SQL[] =
+    "UPDATE vms SET fs9p_name='%s' WHERE name='%s'";
 
-static const char *nm_form_msg[] = {
-    "Enable sharing", "Path to directory",
-    "Name of the share", NULL
+static const char NM_9P_FORM_MODE[] = "Enable sharing";
+static const char NM_9P_FORM_PATH[] = "Path to directory";
+static const char NM_9P_FORM_NAME[] = "Name of the share";
+
+static void nm_9p_init_windows(nm_form_t *form);
+static void nm_9p_fields_setup(const nm_vmctl_data_t *cur);
+static size_t nm_9p_labels_setup();
+static int nm_9p_get_data(nm_9p_data_t *data, const nm_vmctl_data_t *cur);
+static void nm_9p_update_db(const nm_str_t *name, const nm_9p_data_t *data);
+
+enum {
+    NM_LBL_9PMODE = 0, NM_FLD_9PMODE,
+    NM_LBL_9PPATH, NM_FLD_9PPATH,
+    NM_LBL_9PNAME, NM_FLD_9PNAME,
+    NM_FLD_COUNT
 };
 
 static nm_field_t *fields[NM_FLD_COUNT + 1];
 
-static int nm_9p_get_data(nm_9p_data_t *data, const nm_vmctl_data_t *cur);
-static void nm_9p_update_db(const nm_str_t *name, const nm_9p_data_t *data);
-
-void nm_9p_share(const nm_str_t *name)
+static void nm_9p_init_windows(nm_form_t *form)
 {
-    nm_form_t *form = NULL;
-    nm_vmctl_data_t vm = NM_VMCTL_INIT_DATA;
-    nm_9p_data_t data = NM_INIT_9P_DATA;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
-    size_t msg_len = nm_max_msg_len(nm_form_msg);
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
 
-    if (nm_form_calc_size(msg_len, NM_FLD_COUNT, &form_data) != NM_OK)
-        return;
-
-    werase(action_window);
-    werase(help_window);
+    nm_init_side();
     nm_init_action(_(NM_MSG_9P_SHARE));
     nm_init_help_edit();
 
+    nm_print_vm_menu(NULL);
+}
+
+void nm_9p_share(const nm_str_t *name)
+{
+    nm_form_data_t *form_data = NULL;
+    nm_form_t *form = NULL;
+    nm_vmctl_data_t vm = NM_VMCTL_INIT_DATA;
+    nm_9p_data_t data = NM_INIT_9P_DATA;
+    size_t msg_len;
+
+    nm_9p_init_windows(NULL);
+
     nm_vmctl_get_data(name, &vm);
 
-    for (size_t n = 0; n < NM_FLD_COUNT; ++n)
-        fields[n] = new_field(1, form_data.form_len, n * 2, 0, 0, 0);
+    msg_len = nm_9p_labels_setup();
 
+    form_data = nm_form_data_new(
+        action_window, nm_9p_init_windows, msg_len, NM_FLD_COUNT / 2, NM_TRUE);
+
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
+        goto out;
+
+    for (size_t n = 0; n < NM_FLD_COUNT; n += 2) {
+        fields[n] = nm_field_new(NM_FIELD_LABEL, n / 2, form_data);
+        fields[n + 1] = nm_field_new(NM_FIELD_EDIT, n / 2, form_data);
+    }
     fields[NM_FLD_COUNT] = NULL;
 
-    set_field_type(fields[NM_FLD_9PMODE], TYPE_ENUM, nm_form_yes_no, false, false);
-    set_field_type(fields[NM_FLD_9PPATH], TYPE_REGEXP, "^/.*");
-    set_field_type(fields[NM_FLD_9PNAME], TYPE_REGEXP, ".*");
-    field_opts_off(fields[NM_FLD_9PPATH], O_STATIC);
-    field_opts_off(fields[NM_FLD_9PNAME], O_STATIC);
+    nm_9p_labels_setup();
+    nm_9p_fields_setup(&vm);
 
-    set_field_buffer(fields[NM_FLD_9PMODE], 0,
-        (nm_str_cmp_st(nm_vect_str(&vm.main, NM_SQL_9FLG),
-            NM_ENABLE) == NM_OK) ? "yes" : "no");
-    set_field_buffer(fields[NM_FLD_9PPATH], 0, nm_vect_str_ctx(&vm.main, NM_SQL_9PTH));
-    set_field_buffer(fields[NM_FLD_9PNAME], 0, nm_vect_str_ctx(&vm.main, NM_SQL_9ID));
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
 
-    for (size_t n = 0, y = 1, x = 2; n < NM_FLD_COUNT; n++) {
-        mvwaddstr(form_data.form_window, y, x, _(nm_form_msg[n]));
-        y += 2;
-    }
-
-    form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    if (nm_draw_form(action_window, form) != NM_OK)
+    if (nm_form_draw(&form) != NM_OK)
         goto out;
 
     if (nm_9p_get_data(&data, &vm) != NM_OK)
@@ -94,8 +104,56 @@ out:
     nm_str_free(&data.mode);
     nm_str_free(&data.name);
     nm_str_free(&data.path);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields);
     nm_vmctl_free_data(&vm);
-    nm_form_free(form, fields);
+}
+
+static void nm_9p_fields_setup(const nm_vmctl_data_t *cur)
+{
+    set_field_type(fields[NM_FLD_9PMODE], TYPE_ENUM, nm_form_yes_no, false, false);
+    set_field_type(fields[NM_FLD_9PPATH], TYPE_REGEXP, "^/.*");
+    set_field_type(fields[NM_FLD_9PNAME], TYPE_REGEXP, ".*");
+    field_opts_off(fields[NM_FLD_9PPATH], O_STATIC);
+    field_opts_off(fields[NM_FLD_9PNAME], O_STATIC);
+
+    set_field_buffer(fields[NM_FLD_9PMODE], 0,
+        (nm_str_cmp_st(nm_vect_str(&cur->main, NM_SQL_9FLG),
+            NM_ENABLE) == NM_OK) ? "yes" : "no");
+    set_field_buffer(fields[NM_FLD_9PPATH], 0, nm_vect_str_ctx(&cur->main, NM_SQL_9PTH));
+    set_field_buffer(fields[NM_FLD_9PNAME], 0, nm_vect_str_ctx(&cur->main, NM_SQL_9ID));
+}
+
+static size_t nm_9p_labels_setup()
+{
+    nm_str_t buf = NM_INIT_STR;
+    size_t max_label_len = 0;
+
+    for (size_t n = 0; n < NM_FLD_COUNT; n++) {
+        switch (n) {
+        case NM_LBL_9PMODE:
+            nm_str_format(&buf, "%s", _(NM_9P_FORM_MODE));
+            break;
+        case NM_LBL_9PPATH:
+            nm_str_format(&buf, "%s", _(NM_9P_FORM_PATH));
+            break;
+        case NM_LBL_9PNAME:
+            nm_str_format(&buf, "%s", _(NM_9P_FORM_NAME));
+            break;
+        default:
+            continue;
+        }
+
+        if (buf.len > max_label_len)
+            max_label_len = buf.len;
+
+        if (fields[n])
+            set_field_buffer(fields[n], 0, buf.data);
+    }
+
+    nm_str_free(&buf);
+    return max_label_len;
 }
 
 static int nm_9p_get_data(nm_9p_data_t *data, const nm_vmctl_data_t *cur)
@@ -114,8 +172,8 @@ static int nm_9p_get_data(nm_9p_data_t *data, const nm_vmctl_data_t *cur)
     else if (nm_str_cmp_st(nm_vect_str(&cur->main, NM_SQL_9FLG), NM_ENABLE) != NM_OK)
             goto out;
 
-    nm_form_check_data(_(nm_form_msg[1]), data->path, err);
-    nm_form_check_data(_(nm_form_msg[2]), data->name, err);
+    nm_form_check_data(_(NM_9P_FORM_PATH), data->path, err);
+    nm_form_check_data(_(NM_9P_FORM_NAME), data->name, err);
 
     if ((rc = nm_print_empty_fields(&err)) == NM_ERR)
         nm_vect_free(&err, NULL);

--- a/src/nm_9p_share.c
+++ b/src/nm_9p_share.c
@@ -87,6 +87,7 @@ void nm_9p_share(const nm_str_t *name)
 
     nm_9p_labels_setup();
     nm_9p_fields_setup(&vm);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_9p_share.c
+++ b/src/nm_9p_share.c
@@ -129,6 +129,7 @@ static size_t nm_9p_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
         switch (n) {
@@ -145,8 +146,9 @@ static size_t nm_9p_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields[n])
             set_field_buffer(fields[n], 0, buf.data);

--- a/src/nm_add_drive.c
+++ b/src/nm_add_drive.c
@@ -130,6 +130,7 @@ static size_t nm_add_drive_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
         switch (n) {
@@ -147,8 +148,9 @@ static size_t nm_add_drive_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields[n])
             set_field_buffer(fields[n], 0, buf.data);

--- a/src/nm_add_drive.c
+++ b/src/nm_add_drive.c
@@ -90,6 +90,7 @@ void nm_add_drive(const nm_str_t *name)
 
     set_field_buffer(fields[NM_FLD_DRVTYPE], 0, NM_DEFAULT_DRVINT);
     set_field_buffer(fields[NM_FLD_DISCARD], 0, nm_form_yes_no[1]);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_add_drive.c
+++ b/src/nm_add_drive.c
@@ -15,29 +15,46 @@ static const char NM_DRIVE_FORM_DIS[] = "Discard mode";
 static const char NM_DRIVE_SZ_START[] = "Size [1-";
 static const char NM_DRIVE_SZ_END[] = "]Gb";
 
-enum {
-    NM_FLD_DRVSIZE = 0,
-    NM_FLD_DRVTYPE,
-    NM_FLD_DISCARD,
-    NM_FLD_COUNT
-};
-
+static void nm_add_drive_init_windows(nm_form_t *form);
+static size_t nm_add_drive_labels_setup();
 static void nm_add_drive_to_db(const nm_str_t *name, const nm_str_t *size,
                                const nm_str_t *type, const nm_vect_t *drives,
                                const nm_str_t *discard);
 
+enum {
+    NM_LBL_DRVSIZE = 0, NM_FLD_DRVSIZE,
+    NM_LBL_DRVTYPE, NM_FLD_DRVTYPE,
+    NM_LBL_DISCARD, NM_FLD_DISCARD,
+    NM_FLD_COUNT
+};
+
+static nm_field_t *fields[NM_FLD_COUNT + 1];
+
+static void nm_add_drive_init_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
+
+    nm_init_side();
+    nm_init_action(_(NM_MSG_VDRIVE_ADD));
+    nm_init_help_edit();
+
+    nm_print_vm_menu(NULL);
+}
+
 void nm_add_drive(const nm_str_t *name)
 {
+    nm_form_data_t *form_data = NULL;
     nm_form_t *form = NULL;
-    nm_field_t *fields[NM_FLD_COUNT+ 1] = {NULL};
-    nm_str_t buf = NM_INIT_STR;
     nm_str_t drv_size = NM_INIT_STR;
     nm_str_t drv_type = NM_INIT_STR;
     nm_str_t discard = NM_INIT_STR;
     nm_vmctl_data_t vm = NM_VMCTL_INIT_DATA;
     nm_vect_t err = NM_INIT_VECT;
-    nm_vect_t msg_fields = NM_INIT_VECT;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
     size_t msg_len;
 
     nm_vmctl_get_data(name, &vm);
@@ -49,27 +66,23 @@ void nm_add_drive(const nm_str_t *name)
         goto out;
     }
 
-    werase(action_window);
-    werase(help_window);
-    nm_init_action(_(NM_MSG_VDRIVE_ADD));
-    nm_init_help_edit();
+    nm_add_drive_init_windows(NULL);
 
-    nm_str_format(&buf, "%s%u%s",
-        _(NM_DRIVE_SZ_START), nm_hw_disk_free(), _(NM_DRIVE_SZ_END));
+    msg_len = nm_add_drive_labels_setup();
 
-    nm_vect_insert(&msg_fields, buf.data, buf.len + 1, NULL);
-    nm_vect_insert(&msg_fields, _(NM_DRIVE_FORM_MSG),
-            strlen(_(NM_DRIVE_FORM_MSG)) + 1, NULL);
-    nm_vect_insert(&msg_fields, _(NM_DRIVE_FORM_DIS),
-            strlen(_(NM_DRIVE_FORM_DIS)) + 1, NULL);
-    nm_vect_end_zero(&msg_fields);
-    msg_len = nm_max_msg_len((const char **) msg_fields.data);
+    form_data = nm_form_data_new(
+        action_window, nm_add_drive_init_windows, msg_len, NM_FLD_COUNT / 2, NM_TRUE);
 
-    if (nm_form_calc_size(msg_len, NM_FLD_COUNT, &form_data) != NM_OK)
-        return;
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
+        goto out;
 
-    for (size_t n = 0; n < NM_FLD_COUNT; ++n)
-        fields[n] = new_field(1, form_data.form_len, n * 2, 0, 0, 0);
+    for (size_t n = 0; n < NM_FLD_COUNT; n += 2) {
+        fields[n] = nm_field_new(NM_FIELD_LABEL, n / 2, form_data);
+        fields[n + 1] = nm_field_new(NM_FIELD_EDIT, n / 2, form_data);
+    }
+    fields[NM_FLD_COUNT] = NULL;
+
+    nm_add_drive_labels_setup();
 
     set_field_type(fields[NM_FLD_DRVSIZE], TYPE_INTEGER, 0, 1, nm_hw_disk_free());
     set_field_type(fields[NM_FLD_DRVTYPE], TYPE_ENUM, nm_form_drive_drv, false, false);
@@ -78,20 +91,20 @@ void nm_add_drive(const nm_str_t *name)
     set_field_buffer(fields[NM_FLD_DRVTYPE], 0, NM_DEFAULT_DRVINT);
     set_field_buffer(fields[NM_FLD_DISCARD], 0, nm_form_yes_no[1]);
 
-    for (size_t n = 0, y = 1, x = 2; n < NM_FLD_COUNT; n++) {
-        mvwaddstr(form_data.form_window, y, x, msg_fields.data[n]);
-        y += 2;
-    }
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
 
-    form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    if (nm_draw_form(action_window, form) != NM_OK)
+    if (nm_form_draw(&form) != NM_OK)
         goto out;
 
-    //@TODO Fix nm_bug call "nm_add_drive: cannot create image file" when size field is empty
     nm_get_field_buf(fields[NM_FLD_DRVSIZE], &drv_size);
     nm_get_field_buf(fields[NM_FLD_DRVTYPE], &drv_type);
     nm_get_field_buf(fields[NM_FLD_DISCARD], &discard);
-    nm_form_check_data(_("Size"), buf, err);
+
+    if (!drv_size.len) {
+        nm_warn(_(NM_MSG_DRV_SIZE));
+        goto out;
+    }
 
     if (nm_print_empty_fields(&err) == NM_ERR) {
         nm_vect_free(&err, NULL);
@@ -104,13 +117,45 @@ void nm_add_drive(const nm_str_t *name)
 
 out:
     NM_FORM_EXIT();
-    nm_vect_free(&msg_fields, NULL);
     nm_vmctl_free_data(&vm);
-    nm_form_free(form, fields);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields);
     nm_str_free(&drv_size);
     nm_str_free(&drv_type);
-    nm_str_free(&buf);
     nm_str_free(&discard);
+}
+
+static size_t nm_add_drive_labels_setup()
+{
+    nm_str_t buf = NM_INIT_STR;
+    size_t max_label_len = 0;
+
+    for (size_t n = 0; n < NM_FLD_COUNT; n++) {
+        switch (n) {
+        case NM_LBL_DRVSIZE:
+            nm_str_format(&buf, "%s%u%s",
+                _(NM_DRIVE_SZ_START), nm_hw_disk_free(), _(NM_DRIVE_SZ_END));
+            break;
+        case NM_LBL_DRVTYPE:
+            nm_str_format(&buf, "%s", _(NM_DRIVE_FORM_MSG));
+            break;
+        case NM_LBL_DISCARD:
+            nm_str_format(&buf, "%s", _(NM_DRIVE_FORM_DIS));
+            break;
+        default:
+            continue;
+        }
+
+        if (buf.len > max_label_len)
+            max_label_len = buf.len;
+
+        if (fields[n])
+            set_field_buffer(fields[n], 0, buf.data);
+    }
+
+    nm_str_free(&buf);
+    return max_label_len;
 }
 
 void nm_del_drive(const nm_str_t *name)

--- a/src/nm_add_vm.c
+++ b/src/nm_add_vm.c
@@ -185,6 +185,7 @@ static size_t nm_add_vm_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
         switch (n) {
@@ -227,8 +228,9 @@ static size_t nm_add_vm_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields[n])
             set_field_buffer(fields[n], 0, buf.data);

--- a/src/nm_add_vm.c
+++ b/src/nm_add_vm.c
@@ -114,6 +114,7 @@ static void nm_add_vm_main()
 
     nm_add_vm_labels_setup();
     nm_add_vm_fields_setup();
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_clone_vm.c
+++ b/src/nm_clone_vm.c
@@ -69,6 +69,7 @@ void nm_clone_vm(const nm_str_t *name)
     set_field_type(fields[1], TYPE_REGEXP, "^[a-zA-Z0-9_-]{1,30} *$");
     nm_str_format(&buf, "%s-clone", name->data);
     set_field_buffer(fields[1], 0, buf.data);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_edit_boot.c
+++ b/src/nm_edit_boot.c
@@ -81,6 +81,7 @@ void nm_edit_boot(const nm_str_t *name)
 
     nm_edit_boot_labels_setup();
     nm_edit_boot_fields_setup(&cur_settings);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_edit_boot.c
+++ b/src/nm_edit_boot.c
@@ -137,6 +137,7 @@ static size_t nm_edit_boot_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
         switch (n) {
@@ -168,8 +169,9 @@ static size_t nm_edit_boot_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields[n])
             set_field_buffer(fields[n], 0, buf.data);

--- a/src/nm_edit_boot.c
+++ b/src/nm_edit_boot.c
@@ -3,63 +3,89 @@
 #include <nm_utils.h>
 #include <nm_string.h>
 #include <nm_window.h>
+#include <nm_menu.h>
 #include <nm_database.h>
 #include <nm_vm_control.h>
 #include <nm_edit_boot.h>
 
+static const char NM_EDIT_BOOT_FORM_INST[] = "OS Installed";
+static const char NM_EDIT_BOOT_FORM_SRCP[] = "Path to ISO/IMG";
+static const char NM_EDIT_BOOT_FORM_BIOS[] = "Path to BIOS";
+static const char NM_EDIT_BOOT_FORM_KERN[] = "Path to kernel";
+static const char NM_EDIT_BOOT_FORM_CMDL[] = "Kernel cmdline";
+static const char NM_EDIT_BOOT_FORM_INIT[] = "Path to initrd";
+static const char NM_EDIT_BOOT_FORM_DEBP[] = "GDB debug port";
+static const char NM_EDIT_BOOT_FORM_DEBF[] = "Freeze after start";
+
+static void nm_edit_boot_init_windows(nm_form_t *form);
+static void nm_edit_boot_fields_setup(const nm_vmctl_data_t *cur);
+static size_t nm_edit_boot_labels_setup();
+static int nm_edit_boot_get_data(nm_vm_boot_t *vm);
+static void nm_edit_boot_update_db(const nm_str_t *name, nm_vm_boot_t *vm);
+
 enum {
-    NM_FLD_INST = 0,
-    NM_FLD_SRCP,
-    NM_FLD_BIOS,
-    NM_FLD_KERN,
-    NM_FLD_CMDL,
-    NM_FLD_INIT,
-    NM_FLD_DEBP,
-    NM_FLD_DEBF,
+    NM_LBL_INST = 0,  NM_FLD_INST,
+    NM_LBL_SRCP, NM_FLD_SRCP,
+    NM_LBL_BIOS, NM_FLD_BIOS,
+    NM_LBL_KERN, NM_FLD_KERN,
+    NM_LBL_CMDL, NM_FLD_CMDL,
+    NM_LBL_INIT, NM_FLD_INIT,
+    NM_LBL_DEBP, NM_FLD_DEBP,
+    NM_LBL_DEBF, NM_FLD_DEBF,
     NM_FLD_COUNT
 };
 
 static nm_field_t *fields[NM_FLD_COUNT + 1];
 
-static const char *nm_form_msg[] = {
-    "OS Installed", "Path to ISO/IMG", "Path to BIOS",
-    "Path to kernel", "Kernel cmdline", "Path to initrd",
-    "GDB debug port", "Freeze after start", NULL
-};
-
-static void nm_edit_boot_field_setup(const nm_vmctl_data_t *cur);
-static void nm_edit_boot_field_names(nm_window_t *w);
-static int nm_edit_boot_get_data(nm_vm_boot_t *vm);
-static void nm_edit_boot_update_db(const nm_str_t *name, nm_vm_boot_t *vm);
-
-void nm_edit_boot(const nm_str_t *name)
+static void nm_edit_boot_init_windows(nm_form_t *form)
 {
-    nm_form_t *form = NULL;
-    nm_vm_boot_t vm = NM_INIT_VM_BOOT;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
-    nm_vmctl_data_t cur_settings = NM_VMCTL_INIT_DATA;
-    size_t msg_len = nm_max_msg_len(nm_form_msg);
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
 
-    if (nm_form_calc_size(msg_len, NM_FLD_COUNT, &form_data) != NM_OK)
-        return;
-
-    werase(action_window);
-    werase(help_window);
+    nm_init_side();
     nm_init_action(_(NM_MSG_EDIT_BOOT));
     nm_init_help_edit();
 
+    nm_print_vm_menu(NULL);
+}
+
+void nm_edit_boot(const nm_str_t *name)
+{
+    nm_form_data_t *form_data = NULL;
+    nm_form_t *form = NULL;
+    nm_vm_boot_t vm = NM_INIT_VM_BOOT;
+    nm_vmctl_data_t cur_settings = NM_VMCTL_INIT_DATA;
+    size_t msg_len;
+
+    nm_edit_boot_init_windows(NULL);
+
     nm_vmctl_get_data(name, &cur_settings);
 
-    for (size_t n = 0; n < NM_FLD_COUNT; ++n)
-        fields[n] = new_field(1, form_data.form_len, n * 2, 0, 0, 0);
+    msg_len = nm_edit_boot_labels_setup();
 
+    form_data = nm_form_data_new(
+        action_window, nm_edit_boot_init_windows, msg_len, NM_FLD_COUNT / 2, NM_TRUE);
+
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
+        goto out;
+
+    for (size_t n = 0; n < NM_FLD_COUNT; n += 2) {
+        fields[n] = nm_field_new(NM_FIELD_LABEL, n / 2, form_data);
+        fields[n + 1] = nm_field_new(NM_FIELD_EDIT, n / 2, form_data);
+    }
     fields[NM_FLD_COUNT] = NULL;
 
-    nm_edit_boot_field_setup(&cur_settings);
-    nm_edit_boot_field_names(form_data.form_window);
+    nm_edit_boot_labels_setup();
+    nm_edit_boot_fields_setup(&cur_settings);
 
-    form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    if (nm_draw_form(action_window, form) != NM_OK)
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
+
+    if (nm_form_draw(&form) != NM_OK)
         goto out;
 
     if (nm_edit_boot_get_data(&vm) != NM_OK)
@@ -71,10 +97,12 @@ out:
     NM_FORM_EXIT();
     nm_vmctl_free_data(&cur_settings);
     nm_vm_free_boot(&vm);
-    nm_form_free(form, fields);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields);
 }
 
-static void nm_edit_boot_field_setup(const nm_vmctl_data_t *cur)
+static void nm_edit_boot_fields_setup(const nm_vmctl_data_t *cur)
 {
     for (size_t n = 1; n < NM_FLD_COUNT; n++)
         field_opts_off(fields[n], O_STATIC);
@@ -103,24 +131,57 @@ static void nm_edit_boot_field_setup(const nm_vmctl_data_t *cur)
         set_field_buffer(fields[NM_FLD_DEBF], 0, nm_form_yes_no[0]);
     else
         set_field_buffer(fields[NM_FLD_DEBF], 0, nm_form_yes_no[1]);
-
-    for (size_t n = 0; n < NM_FLD_COUNT; n++)
-        set_field_status(fields[n], 0);
 }
 
-static void nm_edit_boot_field_names(nm_window_t *w)
+static size_t nm_edit_boot_labels_setup()
 {
-    int y = 1, x = 2, mult = 2;
+    nm_str_t buf = NM_INIT_STR;
+    size_t max_label_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
-        mvwaddstr(w, y, x, _(nm_form_msg[n]));
-        y += mult;
+        switch (n) {
+        case NM_LBL_INST:
+            nm_str_format(&buf, "%s", _(NM_EDIT_BOOT_FORM_INST));
+            break;
+        case NM_LBL_SRCP:
+            nm_str_format(&buf, "%s", _(NM_EDIT_BOOT_FORM_SRCP));
+            break;
+        case NM_LBL_BIOS:
+            nm_str_format(&buf, "%s", _(NM_EDIT_BOOT_FORM_BIOS));
+            break;
+        case NM_LBL_KERN:
+            nm_str_format(&buf, "%s", _(NM_EDIT_BOOT_FORM_KERN));
+            break;
+        case NM_LBL_CMDL:
+            nm_str_format(&buf, "%s", _(NM_EDIT_BOOT_FORM_CMDL));
+            break;
+        case NM_LBL_INIT:
+            nm_str_format(&buf, "%s", _(NM_EDIT_BOOT_FORM_INIT));
+            break;
+        case NM_LBL_DEBP:
+            nm_str_format(&buf, "%s", _(NM_EDIT_BOOT_FORM_DEBP));
+            break;
+        case NM_LBL_DEBF:
+            nm_str_format(&buf, "%s", _(NM_EDIT_BOOT_FORM_DEBF));
+            break;
+        default:
+            continue;
+        }
+
+        if (buf.len > max_label_len)
+            max_label_len = buf.len;
+
+        if (fields[n])
+            set_field_buffer(fields[n], 0, buf.data);
     }
+
+    nm_str_free(&buf);
+    return max_label_len;
 }
 
 static int nm_edit_boot_get_data(nm_vm_boot_t *vm)
 {
-    int rc = NM_OK;
+    int rc;
     nm_vect_t err = NM_INIT_VECT;
     nm_str_t inst = NM_INIT_STR;
     nm_str_t debug_freeze = NM_INIT_STR;

--- a/src/nm_edit_net.c
+++ b/src/nm_edit_net.c
@@ -238,6 +238,7 @@ nm_edit_net_action(const nm_str_t *name, const nm_vmctl_data_t *vm, size_t if_id
 
     nm_edit_net_labels_setup();
     nm_edit_net_fields_setup(vm, if_idx);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_edit_net.c
+++ b/src/nm_edit_net.c
@@ -339,6 +339,7 @@ static size_t nm_edit_net_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
         switch (n) {
@@ -375,8 +376,9 @@ static size_t nm_edit_net_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields[n])
             set_field_buffer(fields[n], 0, buf.data);

--- a/src/nm_edit_net.c
+++ b/src/nm_edit_net.c
@@ -9,13 +9,6 @@
 #include <nm_edit_net.h>
 
 #if defined (NM_OS_LINUX)
-    enum {NM_NET_FIELDS_NUM = 9};
-#else
-    enum {NM_NET_FIELDS_NUM = 6};
-#endif
-
-
-#if defined (NM_OS_LINUX)
 static const size_t NM_NET_MACVTAP_NUM = 2;
 #endif
 
@@ -49,11 +42,22 @@ typedef struct {
                         NM_INIT_STR }
 #endif
 
-static nm_field_t *fields[NM_NET_FIELDS_NUM + 1];
+static const char NM_EDIT_NET_FORM_NDRV[] = "Net driver";
+static const char NM_EDIT_NET_FORM_MADR[] = "Mac address";
+static const char NM_EDIT_NET_FORM_IPV4[] = "IPv4 address";
+#if defined (NM_OS_LINUX)
+static const char NM_EDIT_NET_FORM_VHST[] = "Enable vhost";
+static const char NM_EDIT_NET_FORM_MTAP[] = "Enable MacVTap";
+static const char NM_EDIT_NET_FORM_PETH[] = "MacVTap iface";
+#endif
+static const char NM_EDIT_NET_FORM_USER[] = "User mode";
+static const char NM_EDIT_NET_FORM_FWD[]  = "Port forwarding";
+static const char NM_EDIT_NET_FORM_SMB[]  = "Share folder";
 
-static void nm_edit_net_field_names(nm_window_t *w);
-static void nm_edit_net_field_setup(const nm_vmctl_data_t *vm,
-                                    size_t if_idx);
+static void nm_edit_net_init_main_windows(nm_form_t *form);
+static void nm_edit_net_init_edit_windows(nm_form_t *form);
+static void nm_edit_net_fields_setup(const nm_vmctl_data_t *vm, size_t if_idx);
+static size_t nm_edit_net_labels_setup();
 static int nm_edit_net_get_data(const nm_str_t *name, nm_iface_t *ifp);
 static void nm_edit_net_update_db(const nm_str_t *name, nm_iface_t *ifp);
 static inline void nm_edit_net_iface_free(nm_iface_t *ifp);
@@ -62,36 +66,54 @@ static int nm_edit_net_action(const nm_str_t *name,
                               const nm_vmctl_data_t *vm, size_t if_idx);
 static int nm_verify_portfwd(const nm_str_t *fwd);
 
-static const char *nm_form_msg[] = {
-    "Net driver",
-    "Mac address",
-    "IPv4 address",
-#if defined (NM_OS_LINUX)
-    "Enable vhost",
-    "Enable MacVTap",
-    "MacVTap iface",
-#endif
-    "User mode",
-    "Port forwarding",
-    "Share folder",
-    NULL
-};
-
-static nm_form_t *form = NULL;
-
 enum {
-    NM_FLD_NDRV = 0,
-    NM_FLD_MADR,
-    NM_FLD_IPV4,
+    NM_LBL_NDRV, NM_FLD_NDRV,
+    NM_LBL_MADR, NM_FLD_MADR,
+    NM_LBL_IPV4, NM_FLD_IPV4,
 #if defined (NM_OS_LINUX)
-    NM_FLD_VHST,
-    NM_FLD_MTAP,
-    NM_FLD_PETH,
+    NM_LBL_VHST, NM_FLD_VHST,
+    NM_LBL_MTAP, NM_FLD_MTAP,
+    NM_LBL_PETH, NM_FLD_PETH,
 #endif
-    NM_FLD_USER,
-    NM_FLD_FWD,
-    NM_FLD_SMB
+    NM_LBL_USER, NM_FLD_USER,
+    NM_LBL_FWD, NM_FLD_FWD,
+    NM_LBL_SMB, NM_FLD_SMB,
+    NM_FLD_COUNT
 };
+
+static nm_field_t *fields[NM_FLD_COUNT + 1];
+
+static void nm_edit_net_init_main_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
+
+    nm_init_help_iface();
+    nm_init_action(_(NM_MSG_IF_PROP));
+    nm_init_side_if_list();
+
+    nm_print_base_menu(NULL);
+}
+
+static void nm_edit_net_init_edit_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
+
+    nm_init_help_edit();
+    nm_init_action(_(NM_MSG_IF_PROP));
+    nm_init_side_if_list();
+
+    nm_print_base_menu(NULL);
+}
 
 void nm_edit_net(const nm_str_t *name)
 {
@@ -109,12 +131,7 @@ void nm_edit_net(const nm_str_t *name)
         goto out;
     }
 
-    werase(side_window);
-    werase(action_window);
-    werase(help_window);
-    nm_init_help_iface();
-    nm_init_action(_(NM_MSG_IF_PROP));
-    nm_init_side_if_list();
+    nm_edit_net_init_main_windows(NULL);
 
     iface_count = vm.ifs.n_memb / NM_IFS_IDX_COUNT;
 
@@ -137,13 +154,11 @@ void nm_edit_net(const nm_str_t *name)
         nm_menu_scroll(&ifs, vm_list_len, ch);
 
         if (ch == NM_KEY_ENTER) {
-            werase(action_window);
-            nm_init_action(_(NM_MSG_IF_PROP));
-
             if (nm_edit_net_action(name, &vm, ifs.highlight) == NM_OK) {
                 nm_vmctl_free_data(&vm);
                 nm_vmctl_get_data(name, &vm);
             }
+            nm_init_help_iface();
         }
 
         nm_print_base_menu(&ifs);
@@ -152,13 +167,7 @@ void nm_edit_net(const nm_str_t *name)
         nm_print_iface_info(&vm, ifs.highlight);
 
         if (redraw_window) {
-            nm_destroy_windows();
-            endwin();
-            refresh();
-            nm_create_windows();
-            nm_init_help_iface();
-            nm_init_side_if_list();
-            nm_init_action(_(NM_MSG_IF_PROP));
+            nm_edit_net_init_main_windows(NULL);
 
             vm_list_len = (getmaxy(side_window) - 4);
             /* TODO save last pos */
@@ -186,11 +195,12 @@ out:
 static int
 nm_edit_net_action(const nm_str_t *name, const nm_vmctl_data_t *vm, size_t if_idx)
 {
+    nm_form_data_t *form_data = NULL;
+    nm_form_t *form = NULL;
     int rc = NM_OK;
-    size_t msg_len = nm_max_msg_len(nm_form_msg);
     nm_iface_t iface_data = NM_INIT_NET_IF;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
     size_t idx_shift;
+    size_t msg_len;
 
     if (!if_idx) {
         rc = NM_ERR;
@@ -208,46 +218,59 @@ nm_edit_net_action(const nm_str_t *name, const nm_vmctl_data_t *vm, size_t if_id
         goto out;
     }
 
-    werase(help_window);
-    nm_init_help_edit();
+    nm_edit_net_init_edit_windows(NULL);
 
-    if (nm_form_calc_size(msg_len, NM_NET_FIELDS_NUM, &form_data) != NM_OK)
-        return NM_ERR;
+    msg_len = nm_edit_net_labels_setup();
 
-    for (size_t n = 0; n < NM_NET_FIELDS_NUM; ++n)
-        fields[n] = new_field(1, form_data.form_len, n * 2, 0, 0, 0);
+    form_data = nm_form_data_new(
+        action_window, nm_edit_net_init_edit_windows, msg_len, NM_FLD_COUNT / 2, NM_TRUE);
 
-    fields[NM_NET_FIELDS_NUM] = NULL;
-
-    nm_edit_net_field_setup(vm, if_idx);
-    nm_edit_net_field_names(form_data.form_window);
-
-    form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    mvwhline(form_data.form_window, (NM_NET_FIELDS_NUM - 3) * 2,
-            0, ACS_HLINE, getmaxx(form_data.form_window));
-
-    if (nm_draw_form(action_window, form) != NM_OK) {
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK) {
         rc = NM_ERR;
         goto out;
     }
 
-    if (nm_edit_net_get_data(name, &iface_data) != NM_OK)
+    for (size_t n = 0; n < NM_FLD_COUNT; n += 2) {
+        fields[n] = nm_field_new(NM_FIELD_LABEL, n / 2, form_data);
+        fields[n + 1] = nm_field_new(NM_FIELD_EDIT, n / 2, form_data);
+    }
+    fields[NM_FLD_COUNT] = NULL;
+
+    nm_edit_net_labels_setup();
+    nm_edit_net_fields_setup(vm, if_idx);
+
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
+
+    /* Add horisontal line before usernet related stuff */
+    mvwhline(form_data->form_window,
+        NM_LBL_USER, 0, ACS_HLINE, getmaxx(form_data->form_window));
+
+    if (nm_form_draw(&form) != NM_OK) {
+        rc = NM_ERR;
         goto out;
+    }
+
+    if (nm_edit_net_get_data(name, &iface_data) != NM_OK) {
+        rc = NM_ERR;
+        goto out;
+    }
 
     nm_edit_net_update_db(name, &iface_data);
 
 out:
     wtimeout(action_window, -1);
-    delwin(form_data.form_window);
+    delwin(form_data->form_window);
     werase(help_window);
-    nm_init_help_iface();
     nm_edit_net_iface_free(&iface_data);
-    nm_form_free(form, fields);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields);
 
     return rc;
 }
 
-static void nm_edit_net_field_setup(const nm_vmctl_data_t *vm, size_t if_idx)
+static void nm_edit_net_fields_setup(const nm_vmctl_data_t *vm, size_t if_idx)
 {
     size_t mvtap_idx = 0;
     size_t idx_shift;
@@ -310,24 +333,62 @@ static void nm_edit_net_field_setup(const nm_vmctl_data_t *vm, size_t if_idx)
         set_field_buffer(fields[NM_FLD_SMB], 0,
             nm_vect_str_ctx(&vm->ifs, NM_SQL_IF_SMB + idx_shift));
     }
-
-    for (size_t n = 0; n < NM_NET_FIELDS_NUM; n++)
-        set_field_status(fields[n], 0);
 }
 
-static void nm_edit_net_field_names(nm_window_t *w)
+static size_t nm_edit_net_labels_setup()
 {
-    int y = 1, x = 2, mult = 2;
+    nm_str_t buf = NM_INIT_STR;
+    size_t max_label_len = 0;
 
-    for (size_t n = 0; n < NM_NET_FIELDS_NUM; n++) {
-        mvwaddstr(w, y, x, _(nm_form_msg[n]));
-        y += mult;
+    for (size_t n = 0; n < NM_FLD_COUNT; n++) {
+        switch (n) {
+        case NM_LBL_NDRV:
+            nm_str_format(&buf, "%s", _(NM_EDIT_NET_FORM_NDRV));
+            break;
+        case NM_LBL_MADR:
+            nm_str_format(&buf, "%s", _(NM_EDIT_NET_FORM_MADR));
+            break;
+        case NM_LBL_IPV4:
+            nm_str_format(&buf, "%s", _(NM_EDIT_NET_FORM_IPV4));
+            break;
+#if defined (NM_OS_LINUX)
+        case NM_LBL_VHST:
+            nm_str_format(&buf, "%s", _(NM_EDIT_NET_FORM_VHST));
+            break;
+        case NM_LBL_MTAP:
+            nm_str_format(&buf, "%s", _(NM_EDIT_NET_FORM_MTAP));
+            break;
+        case NM_LBL_PETH:
+            nm_str_format(&buf, "%s", _(NM_EDIT_NET_FORM_PETH));
+            break;
+#endif
+        case NM_LBL_USER:
+            nm_str_format(&buf, "%s", _(NM_EDIT_NET_FORM_USER));
+            break;
+        case NM_LBL_FWD:
+            nm_str_format(&buf, "%s", _(NM_EDIT_NET_FORM_FWD));
+            break;
+        case NM_LBL_SMB:
+            nm_str_format(&buf, "%s", _(NM_EDIT_NET_FORM_SMB));
+            break;
+        default:
+            continue;
+        }
+
+        if (buf.len > max_label_len)
+            max_label_len = buf.len;
+
+        if (fields[n])
+            set_field_buffer(fields[n], 0, buf.data);
     }
+
+    nm_str_free(&buf);
+    return max_label_len;
 }
 
 static int nm_edit_net_get_data(const nm_str_t *name, nm_iface_t *ifp)
 {
-    int rc = NM_OK;
+    int rc;
     nm_vect_t err = NM_INIT_VECT;
 
     nm_get_field_buf(fields[NM_FLD_NDRV], &ifp->drv);

--- a/src/nm_edit_vm.c
+++ b/src/nm_edit_vm.c
@@ -97,6 +97,7 @@ void nm_edit_vm(const nm_str_t *name)
 
     nm_edit_vm_labels_setup();
     nm_edit_vm_fields_setup(&cur_settings);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_edit_vm.c
+++ b/src/nm_edit_vm.c
@@ -183,6 +183,7 @@ static size_t nm_edit_vm_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
         switch (n) {
@@ -227,8 +228,9 @@ static size_t nm_edit_vm_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields[n])
             set_field_buffer(fields[n], 0, buf.data);

--- a/src/nm_form.c
+++ b/src/nm_form.c
@@ -202,6 +202,7 @@ nm_form_data_t *nm_form_data_new(
 {
     nm_form_data_t *form_data = nm_alloc(sizeof(nm_form_data_t));
     form_data->parent_window = parent;
+    form_data->form_window = NULL;
     form_data->on_redraw = on_redraw;
     form_data->msg_len = msg_len;
     form_data->field_lines = field_lines;

--- a/src/nm_form.c
+++ b/src/nm_form.c
@@ -11,6 +11,14 @@
 #include <glob.h>
 #include <dirent.h>
 
+static const int ROW_HEIGHT = 1;
+static const int FIELD_HPAD = 2;
+static const int FIELD_VPAD = 1;
+static const int FORM_HPAD = 2;
+static const int FORM_VPAD = 1;
+static const int MIN_EDIT_SIZE = 18;
+static const float FORM_RATIO = 0.80;
+
 const char *nm_form_yes_no[] = {
     "yes",
     "no",
@@ -53,113 +61,312 @@ const char *nm_form_displaytype[] = {
     NULL
 };
 
+void _nc_Free_Type(nm_field_t *field);
+void _nc_Copy_Type(nm_field_t *dst, nm_field_t const *src );
+
 static int nm_append_path(nm_str_t *path);
+static nm_field_t *nm_field_resize(nm_field_t *field, nm_form_data_t *form_data);
+static nm_form_t *nm_form_redraw(nm_form_t *form);
 
-void nm_form_free(nm_form_t *form, nm_field_t **fields)
+nm_field_t *nm_field_new(nm_field_type_t type, int row, nm_form_data_t *form_data)
 {
-    if (form) {
-        unpost_form(form);
-        free_form(form);
-        form = NULL;
+    nm_field_data_t *field_data = NULL;
+    nm_field_t *field = NULL;
+    int height = ROW_HEIGHT;
+    int top = (ROW_HEIGHT + form_data->field_vpad) * row;
+    int width;
+    int left;
+
+    field_data = (nm_field_data_t *)nm_alloc(sizeof(nm_field_data_t));
+
+    field_data->type = type;
+    field_data->row = row;
+    field_data->children.n_memb = 0;
+    field_data->children.n_alloc = 0;
+    field_data->children.data = NULL;
+    field_data->on_change = NULL;
+
+    switch (type) {
+        case NM_FIELD_LABEL:
+            width = form_data->msg_len;
+            left = 0;
+            break;
+        case NM_FIELD_EDIT:
+            width = (form_data->form_len - form_data->msg_len - form_data->field_hpad);
+            left = (form_data->msg_len + form_data->field_hpad);
+            break;
+        case NM_FIELD_DEFAULT:
+            width = form_data->form_len;
+            left = 0;
+            break;
+        default:
+            nm_bug("%s: %s", __func__, "Unknown field type");
+            break;
     }
 
-    if (fields) {
-        for (; *fields; fields++) {
-            free_field(*fields);
-            *fields = NULL;
-        }
+    field = new_field(height, width, top, left, 0, 0);
+    if (field == NULL)
+         nm_bug("%s: %s", __func__, strerror(errno));
+    set_field_userptr(field, field_data);
+
+    switch (type) {
+        case NM_FIELD_LABEL:
+            field_opts_off(field, O_ACTIVE);
+            if (form_data->color) {
+                set_field_fore(field, COLOR_PAIR(NM_COLOR_BLACK));
+                set_field_back(field, COLOR_PAIR(NM_COLOR_BLACK));
+            }
+            break;
+        case NM_FIELD_EDIT:
+        case NM_FIELD_DEFAULT:
+            field_opts_off(field, O_STATIC);
+            break;
+        default:
+            nm_bug("%s: %s", __func__, "Unknown field type");
+            break;
     }
 
-    curs_set(0);
+    set_field_status(field, 0);
+    return field;
 }
 
-nm_form_t *
-nm_post_form(nm_window_t *w, nm_field_t **field, int begin_x, int color)
+static nm_field_t *nm_field_resize(nm_field_t *field, nm_form_data_t *form_data)
 {
-    nm_form_t *form;
-    int rows, cols;
+    nm_field_data_t *field_data = (nm_field_data_t *)field_userptr(field);
+    nm_field_t *field_ = NULL;
+    int height = ROW_HEIGHT;
+    int top = (ROW_HEIGHT + form_data->field_vpad) * field_data->row;
+    int width;
+    int left;
 
-    if (color)
-        wbkgd(w, COLOR_PAIR(NM_COLOR_BLACK));
+    switch (field_data->type) {
+        case NM_FIELD_LABEL:
+            width = form_data->msg_len;
+            left = 0;
+            break;
+        case NM_FIELD_EDIT:
+            width = (form_data->form_len - form_data->msg_len - form_data->field_hpad);
+            left = (form_data->msg_len + form_data->field_hpad);
+            break;
+        case NM_FIELD_DEFAULT:
+            width = form_data->form_len;
+            left = 0;
+            break;
+        default:
+            nm_bug("%s: %s", __func__, "Unknown field type");
+            break;
+    }
+
+    field_ = new_field(height, width, top, left, 0, 0);
+    if (field_ == NULL)
+         nm_bug("%s: %s", __func__, strerror(errno));
+
+    set_field_userptr(field_, field_data);
+    set_field_opts(field_, field_opts(field));
+    set_field_buffer(field_, 0, field_buffer(field, 0));
+    set_field_fore(field_, field_fore(field));
+    set_field_back(field_, field_back(field));
+    _nc_Free_Type(field_);
+    _nc_Copy_Type(field_, field);
+    //@TODO update children somehow
+
+    free_field(field);
+
+    return field_;
+}
+
+void nm_field_free(nm_field_t *field)
+{
+    if (!field)
+        return;
+
+    nm_field_data_t *field_data = (nm_field_data_t *)field_userptr(field);
+    if (field_data) {
+        nm_vect_free(&field_data->children, NULL);
+        free(field_data);
+    }
+    free_field(field);
+}
+
+void nm_fields_free(nm_field_t **fields)
+{
+    for (; *fields; fields++) {
+        nm_field_free(*fields);
+        *fields = NULL;
+    }
+}
+
+nm_form_data_t *nm_form_data_new(
+    nm_window_t *parent, void (*on_redraw)(nm_form_t *),
+    size_t msg_len, size_t field_lines, int color)
+{
+    nm_form_data_t *form_data = nm_alloc(sizeof(nm_form_data_t));
+    form_data->parent_window = parent;
+    form_data->on_redraw = on_redraw;
+    form_data->msg_len = msg_len;
+    form_data->field_lines = field_lines;
+    form_data->color = color;
+
+    form_data->field_hpad = FIELD_HPAD;
+    form_data->field_vpad = FIELD_VPAD;
+    form_data->form_hpad = FORM_HPAD;
+    form_data->form_vpad = FORM_VPAD;
+    form_data->form_ratio = FORM_RATIO;
+    form_data->min_edit_size = MIN_EDIT_SIZE;
+
+    form_data->w_rows = (ROW_HEIGHT + form_data->field_vpad) * field_lines \
+        + form_data->form_vpad;
+    form_data->w_start_y = NM_WINDOW_HEADER_HEIGHT;
+
+    return form_data;
+}
+
+int nm_form_data_update(nm_form_data_t *form_data, size_t msg_len, size_t field_lines)
+{
+    size_t cols, rows;
+
+    getmaxyx(form_data->parent_window, rows, cols);
+
+    if (msg_len)
+        form_data->msg_len = msg_len;
+    if (field_lines)
+        form_data->field_lines = field_lines;
+
+    form_data->w_rows = (ROW_HEIGHT + form_data->field_vpad) * form_data->field_lines \
+        + form_data->form_vpad;
+    form_data->w_cols = cols * form_data->form_ratio;
+    form_data->form_len = form_data->w_cols \
+        - form_data->field_hpad  - form_data->form_hpad;
+    form_data->w_start_x = ((1 - form_data->form_ratio) * cols) / 2;
+
+    if (form_data->w_cols < (form_data->msg_len + form_data->min_edit_size) ||
+        form_data->w_rows > rows - form_data->w_start_y - form_data->form_vpad) {
+        nm_warn(_(NM_MSG_SMALL_WIN));
+        return NM_ERR;
+    }
+
+    if (form_data->form_window)
+        delwin(form_data->form_window);
+
+    form_data->form_window = derwin(
+        form_data->parent_window,
+        form_data->w_rows, form_data->w_cols,
+        form_data->w_start_y, form_data->w_start_x
+    );
+
+    return NM_OK;
+}
+
+void nm_form_data_free(nm_form_data_t *form_data)
+{
+    if (form_data) {
+        if (form_data->form_window)
+            delwin(form_data->form_window);
+        free(form_data);
+    }
+}
+
+nm_form_t *nm_form_new(nm_form_data_t *form_data, nm_field_t **field)
+{
+    nm_form_t* form;
 
     form = new_form(field);
     if (form == NULL)
          nm_bug("%s: %s", __func__, strerror(errno));
 
-    set_form_win(form, w);
-    scale_form(form, &rows, &cols);
-    set_form_sub(form, derwin(w, rows, cols, 1, begin_x));
-    post_form(form);
-    curs_set(1);
+    set_form_userptr(form, form_data);
+    set_form_win(form, form_data->form_window);
 
     return form;
 }
 
-int nm_draw_form(nm_window_t *w, nm_form_t *form)
+void nm_form_window_init()
 {
+    nm_destroy_windows();
+    endwin();
+    refresh();
+    nm_create_windows();
+}
+
+void nm_form_post(nm_form_t *form)
+{
+    int rows, cols;
+    nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+
+    if (form_data->color)
+        wbkgd(form_data->form_window, COLOR_PAIR(NM_COLOR_BLACK));
+
+    scale_form(form, &rows, &cols);
+    set_form_sub(form,
+        derwin(form_data->form_window,
+            rows, cols, form_data->form_vpad, form_data->form_hpad));
+    post_form(form);
+    curs_set(1);
+}
+
+int nm_form_draw(nm_form_t **form)
+{
+    nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(*form);
     int confirm = NM_ERR, rc = NM_OK;
     int ch;
     nm_str_t buf = NM_INIT_STR;
 
-    wtimeout(w, 100);
+    wtimeout(form_data->parent_window, 100);
 
-    while ((ch = wgetch(w)) != NM_KEY_ESC) {
-        if (confirm == NM_OK)
-            break;
-
+    while (confirm != NM_OK && (ch = wgetch(form_data->parent_window)) != NM_KEY_ESC) {
         switch(ch) {
         case KEY_DOWN:
-            form_driver(form, REQ_VALIDATION);
-            form_driver(form, REQ_NEXT_FIELD);
-            form_driver(form, REQ_END_LINE);
+            form_driver(*form, REQ_VALIDATION);
+            form_driver(*form, REQ_NEXT_FIELD);
+            form_driver(*form, REQ_END_LINE);
             break;
 
         case KEY_UP:
-            form_driver(form, REQ_VALIDATION);
-            form_driver(form, REQ_PREV_FIELD);
-            form_driver(form, REQ_END_LINE);
+            form_driver(*form, REQ_VALIDATION);
+            form_driver(*form, REQ_PREV_FIELD);
+            form_driver(*form, REQ_END_LINE);
             break;
 
         case KEY_LEFT:
-            if (field_type(current_field(form)) == TYPE_ENUM)
-                form_driver(form, REQ_PREV_CHOICE);
+            if (field_type(current_field(*form)) == TYPE_ENUM)
+                form_driver(*form, REQ_PREV_CHOICE);
             else
-                form_driver(form, REQ_PREV_CHAR);
+                form_driver(*form, REQ_PREV_CHAR);
             break;
 
         case KEY_RIGHT:
-            if (field_type(current_field(form)) == TYPE_ENUM)
-                form_driver(form, REQ_NEXT_CHOICE);
+            if (field_type(current_field(*form)) == TYPE_ENUM)
+                form_driver(*form, REQ_NEXT_CHOICE);
             else
-                form_driver(form, REQ_NEXT_CHAR);
+                form_driver(*form, REQ_NEXT_CHAR);
             break;
 
         case KEY_HOME:
-            form_driver(form, REQ_BEG_LINE);
+            form_driver(*form, REQ_BEG_LINE);
             break;
 
         case KEY_END:
-            form_driver(form, REQ_END_LINE);
+            form_driver(*form, REQ_END_LINE);
             break;
 
         case KEY_BACKSPACE:
         case 127:
-            form_driver(form, REQ_DEL_PREV);
+            form_driver(*form, REQ_DEL_PREV);
             break;
 
         case 0x9: /* TAB KEY */
-            if (field_type(current_field(form)) != TYPE_REGEXP)
+            if (field_type(current_field(*form)) != TYPE_REGEXP)
                 break;
             {
-                form_driver(form, REQ_NEXT_FIELD);
-                form_driver(form, REQ_PREV_FIELD);
-                form_driver(form, REQ_END_FIELD);
+                form_driver(*form, REQ_NEXT_FIELD);
+                form_driver(*form, REQ_PREV_FIELD);
+                form_driver(*form, REQ_END_FIELD);
 
-                nm_get_field_buf(current_field(form), &buf);
+                nm_get_field_buf(current_field(*form), &buf);
 
                 if (nm_append_path(&buf) == NM_OK) {
-                    set_field_buffer(current_field(form), 0, buf.data);
-                    form_driver(form, REQ_END_FIELD);
+                    set_field_buffer(current_field(*form), 0, buf.data);
+                    form_driver(*form, REQ_END_FIELD);
                 }
                 nm_str_trunc(&buf, 0);
             }
@@ -167,14 +374,14 @@ int nm_draw_form(nm_window_t *w, nm_form_t *form)
 
         case KEY_PPAGE:
         case KEY_NPAGE:
-            if (field_type(current_field(form)) == TYPE_ENUM) {
+            if (field_type(current_field(*form)) == TYPE_ENUM) {
                 int drop_ch = 0, x, y;
                 nm_window_t *drop;
                 nm_panel_t *panel;
-                nm_args_t *args = field_arg(current_field(form));
+                nm_args_t *args = field_arg(current_field(*form));
                 nm_menu_data_t list = NM_INIT_MENU_DATA;
                 nm_vect_t values = NM_INIT_VECT;
-                ssize_t list_len = getmaxy(action_window) - 4;
+                ssize_t list_len = getmaxy(form_data->parent_window) - 4;
                 size_t max_len = 0;
 
                 for (ssize_t n = 0; n < args->count; n++) {
@@ -186,8 +393,10 @@ int nm_draw_form(nm_window_t *w, nm_form_t *form)
                     nm_vect_insert_cstr(&values, keyword);
                 }
 
-                getyx(action_window, y, x);
-                x = getbegx(form_sub(form));
+                getyx(form_data->parent_window, y, x);
+                x = getbegx(form_sub(*form)) \
+                    + form_data->msg_len + form_data->field_hpad;
+
                 list.highlight = 1;
                 list_len -= y;
                 if (list_len < args->count)
@@ -201,6 +410,27 @@ int nm_draw_form(nm_window_t *w, nm_form_t *form)
                 panel = new_panel(drop);
                 for(;;) {
                     werase(drop);
+                    if (redraw_window) {
+                        hide_panel(panel);
+                        del_panel(panel);
+                        delwin(drop);
+
+                        ((nm_form_data_t *)form_userptr(*form))->on_redraw(*form);
+                        *form = nm_form_redraw(*form);
+                        wtimeout(form_data->parent_window, 100);
+
+                        getyx(form_data->parent_window, y, x);
+                        x = getbegx(form_sub(*form)) \
+                            + form_data->msg_len + form_data->field_hpad;
+
+                        drop = newwin(list_len + 2, max_len + 4, y + 1, x);
+                        keypad(drop, TRUE);
+                        panel = new_panel(drop);
+
+                        update_panels();
+                        doupdate();
+                        redraw_window = 0;
+                    }
                     nm_menu_scroll(&list, list_len, drop_ch);
                     nm_print_dropdown_menu(&list, drop);
                     drop_ch =  wgetch(drop);
@@ -210,7 +440,7 @@ int nm_draw_form(nm_window_t *w, nm_form_t *form)
                 }
 
                 if (drop_ch == NM_KEY_ENTER) {
-                    set_field_buffer(current_field(form), 0,
+                    set_field_buffer(current_field(*form), 0,
                             args->kwds[(list.item_first + list.highlight) - 1]);
                 }
 
@@ -226,13 +456,20 @@ int nm_draw_form(nm_window_t *w, nm_form_t *form)
 
         case NM_KEY_ENTER:
             confirm = NM_OK;
-            if (form_driver(form, REQ_VALIDATION) != E_OK)
+            if (form_driver(*form, REQ_VALIDATION) != E_OK)
                 rc = NM_ERR;
             break;
 
         default:
-            form_driver(form, ch);
+            form_driver(*form, ch);
             break;
+        }
+
+        if (redraw_window) {
+            ((nm_form_data_t *)form_userptr(*form))->on_redraw(*form);
+            *form = nm_form_redraw(*form);
+            wtimeout(form_data->parent_window, 100);
+            redraw_window = 0;
         }
     }
 
@@ -247,27 +484,54 @@ int nm_draw_form(nm_window_t *w, nm_form_t *form)
     return confirm;
 }
 
-int nm_form_calc_size(size_t max_msg, size_t f_num, nm_form_data_t *form)
+void nm_form_free(nm_form_t *form)
 {
-    size_t cols, rows;
+    if (form) {
+        unpost_form(form);
+        free_form(form);
 
-    getmaxyx(action_window, rows, cols);
+        curs_set(0);
+    }
+}
 
-    form->w_cols = cols * NM_FORM_RATIO;
-    form->w_rows = (f_num * 2) + 1;
+static nm_form_t *nm_form_redraw(nm_form_t *form)
+{
+    nm_form_t *form_;
+    nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+    nm_field_t **fields = form_fields(form);
+    nm_field_t *cur_field = current_field(form);
 
-    if (form->w_cols < (max_msg + 18) ||
-        form->w_rows > rows - 4) {
-        nm_warn(_(NM_MSG_SMALL_WIN));
-        return NM_ERR;
+    form_driver(form, REQ_VALIDATION);
+
+    if (nm_form_data_update(form_data, form_data->msg_len, form_data->field_lines) != NM_OK) {
+        mvwaddstr(form_data->parent_window, 3, 1, _("Window too small"));
+        wrefresh(form_data->parent_window);
+        return form;
     }
 
-    form->w_start_x = ((1 - NM_FORM_RATIO) * cols) / 2;
-    form->form_len = form->w_cols - (max_msg + 6);
-    form->form_window = derwin(action_window, form->w_rows,
-            form->w_cols, 3, form->w_start_x);
+    for (int n = 0; n < form->maxfield; n++) {
+        if(fields[n] == cur_field) {
+            fields[n] = nm_field_resize(fields[n], form_data);
+            cur_field = fields[n];
+        } else {
+            fields[n] = nm_field_resize(fields[n], form_data);
+        }
+    }
 
-    return NM_OK;
+    unpost_form(form);
+    free_form(form);
+
+    form_ = nm_form_new(form_data, fields);
+    if (form_ == NULL)
+         nm_bug("%s: %s", __func__, strerror(errno));
+
+    nm_form_post(form_);
+    if (cur_field) {
+        set_current_field(form_, cur_field);
+        form_driver(form_, REQ_END_LINE);
+    }
+
+    return form_;
 }
 
 void nm_get_field_buf(nm_field_t *f, nm_str_t *res)
@@ -460,6 +724,7 @@ void *nm_spinner(void *data)
 }
 #endif
 
+//@TODO Does this work at all?
 int nm_print_empty_fields(const nm_vect_t *v)
 {
     nm_str_t msg = NM_INIT_STR;

--- a/src/nm_form.c
+++ b/src/nm_form.c
@@ -500,6 +500,7 @@ static nm_form_t *nm_form_redraw(nm_form_t *form)
     nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
     nm_field_t **fields = form_fields(form);
     nm_field_t *cur_field = current_field(form);
+    int maxfield = form->maxfield;
 
     form_driver(form, REQ_VALIDATION);
 
@@ -509,7 +510,10 @@ static nm_form_t *nm_form_redraw(nm_form_t *form)
         return form;
     }
 
-    for (int n = 0; n < form->maxfield; n++) {
+    unpost_form(form);
+    free_form(form);
+
+    for (int n = 0; n < maxfield; n++) {
         if(fields[n] == cur_field) {
             fields[n] = nm_field_resize(fields[n], form_data);
             cur_field = fields[n];
@@ -517,9 +521,6 @@ static nm_form_t *nm_form_redraw(nm_form_t *form)
             fields[n] = nm_field_resize(fields[n], form_data);
         }
     }
-
-    unpost_form(form);
-    free_form(form);
 
     form_ = nm_form_new(form_data, fields);
     if (form_ == NULL)

--- a/src/nm_form.c
+++ b/src/nm_form.c
@@ -168,6 +168,7 @@ static nm_field_t *nm_field_resize(nm_field_t *field, nm_form_data_t *form_data)
     set_field_back(field_, field_back(field));
     _nc_Free_Type(field_);
     _nc_Copy_Type(field_, field);
+    set_field_status(field_, field_status(field));
     //@TODO update children somehow
 
     free_field(field);
@@ -194,6 +195,12 @@ void nm_fields_free(nm_field_t **fields)
         nm_field_free(*fields);
         *fields = NULL;
     }
+}
+
+void nm_fields_unset_status(nm_field_t **fields)
+{
+    for (; *fields; fields++)
+        set_field_status(*fields, 0);
 }
 
 nm_form_data_t *nm_form_data_new(

--- a/src/nm_form.h
+++ b/src/nm_form.h
@@ -127,6 +127,7 @@ typedef struct {
 nm_field_t *nm_field_new(nm_field_type_t type, int row, nm_form_data_t *form_data);
 void nm_field_free(nm_field_t *field);
 void nm_fields_free(nm_field_t **fields);
+void nm_fields_unset_status(nm_field_t **fields);
 
 nm_form_data_t *nm_form_data_new(
     nm_window_t *parent, void (*on_redraw)(nm_form_t *),

--- a/src/nm_lan_settings.c
+++ b/src/nm_lan_settings.c
@@ -252,6 +252,7 @@ static void nm_lan_add_veth(void)
 
     nm_lan_labels_setup();
     nm_lan_fields_setup();
+    nm_fields_unset_status(fields_lan);
 
     form = nm_form_new(form_data, fields_lan);
     nm_form_post(form);
@@ -567,6 +568,7 @@ static void nm_lan_export_svg(const nm_vect_t *veths)
 
     nm_svg_labels_setup();
     nm_svg_fields_setup();
+    nm_fields_unset_status(fields_svg);
 
     form = nm_form_new(form_data, fields_svg);
     nm_form_post(form);

--- a/src/nm_lan_settings.c
+++ b/src/nm_lan_settings.c
@@ -291,6 +291,7 @@ static size_t nm_lan_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_LAN_FLD_COUNT; n++) {
         switch (n) {
@@ -304,8 +305,9 @@ static size_t nm_lan_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields_lan[n])
             set_field_buffer(fields_lan[n], 0, buf.data);
@@ -639,6 +641,7 @@ static size_t nm_svg_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_SVG_FLD_COUNT; n++) {
         switch (n) {
@@ -658,8 +661,9 @@ static size_t nm_svg_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields_svg[n])
             set_field_buffer(fields_svg[n], 0, buf.data);

--- a/src/nm_lan_settings.c
+++ b/src/nm_lan_settings.c
@@ -13,11 +13,29 @@
 
 #if defined (NM_OS_LINUX)
 
+const char NM_LAN_FORM_LNAME[] = "Name";
+const char NM_LAN_FORM_RNAME[] = "Peer name";
+
+static void nm_lan_init_main_windows(nm_form_t *form);
+static void nm_lan_init_add_windows(nm_form_t *form);
+static void nm_lan_fields_setup();
+static size_t nm_lan_labels_setup();
+static void nm_lan_add_veth(void);
+static void nm_lan_del_veth(const nm_str_t *name);
+static void nm_lan_up_veth(const nm_str_t *name);
+static void nm_lan_down_veth(const nm_str_t *name);
+static void nm_lan_veth_info(const nm_str_t *name);
+static int nm_lan_add_get_data(nm_str_t *ln, nm_str_t *rn);
+
 enum {
-    NM_LAN_FIELDS_NUM = 2,
-    NM_SVG_FIELDS_NUM = 4,
+    NM_LAN_LBL_LNAME = 0, NM_LAN_FLD_LNAME,
+    NM_LAN_LBL_RNAME, NM_LAN_FLD_RNAME,
+    NM_LAN_FLD_COUNT
 };
 
+static nm_field_t *fields_lan[NM_LAN_FLD_COUNT + 1];
+
+#if defined (NM_WITH_NETWORK_MAP)
 const char *nm_form_svg_state[] = {
     "UP",
     "DOWN",
@@ -31,39 +49,58 @@ const char *nm_form_svg_layout[] = {
     NULL
 };
 
-extern sig_atomic_t redraw_window;
+const char NM_SVG_FORM_PATH[] = "Export path";
+const char NM_SVG_FORM_TYPE[] = "State";
+const char NM_SVG_FORM_LAYT[] = "Layout";
+const char NM_SVG_FORM_GROUP[] = "Group";
 
-static nm_field_t *fields[NM_LAN_FIELDS_NUM + 1];
-
-enum {
-    NM_FLD_LNAME = 0,
-    NM_FLD_RNAME
-};
-
-static const char *nm_form_add_msg[] = {
-    "Name", "Peer name", NULL
-};
-
-static void nm_lan_add_veth(void);
-static void nm_lan_del_veth(const nm_str_t *name);
-static void nm_lan_up_veth(const nm_str_t *name);
-static void nm_lan_down_veth(const nm_str_t *name);
-static void nm_lan_veth_info(const nm_str_t *name);
-static int nm_lan_add_get_data(nm_str_t *ln, nm_str_t *rn);
-#if defined (NM_WITH_NETWORK_MAP)
-enum {
-    NM_SVG_FLD_PATH = 0,
-    NM_SVG_FLD_TYPE,
-    NM_SVG_FLD_LAYT,
-    NM_SVG_FLD_GROUP
-};
-
-static const char *nm_form_svg_msg[] = {
-    "Export path", "State", "Layout", "Group", NULL
-};
-
+static void nm_svg_init_windows(nm_form_t *form);
+static void nm_svg_fields_setup();
+static size_t nm_svg_labels_setup();
 static void nm_lan_export_svg(const nm_vect_t *veths);
+
+enum {
+    NM_SVG_LBL_PATH = 0, NM_SVG_FLD_PATH,
+    NM_SVG_LBL_TYPE, NM_SVG_FLD_TYPE,
+    NM_SVG_LBL_LAYT, NM_SVG_FLD_LAYT,
+    NM_SVG_LBL_GROUP, NM_SVG_FLD_GROUP,
+    NM_SVG_FLD_COUNT
+};
+
+static nm_field_t *fields_svg[NM_SVG_FLD_COUNT + 1];
 #endif /* NM_WITH_NETWORK_MAP */
+
+static void nm_lan_init_main_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
+
+    nm_init_help_lan();
+    nm_init_action(_(NM_MSG_LAN));
+    nm_init_side_lan();
+
+    nm_print_veth_menu(NULL, 1);
+}
+
+static void nm_lan_init_add_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
+
+    nm_init_help_edit();
+    nm_init_action(_(NM_MSG_ADD_VETH));
+    nm_init_side_lan();
+
+    nm_print_veth_menu(NULL, 1);
+}
 
 void nm_lan_settings(void)
 {
@@ -76,21 +113,12 @@ void nm_lan_settings(void)
 
     nm_lan_create_veth(NM_FALSE);
 
-    werase(side_window);
-    werase(action_window);
-    werase(help_window);
-    nm_init_help_lan();
-    nm_init_action(_(NM_MSG_LAN));
-    nm_init_side_lan();
+    nm_lan_init_main_windows(NULL);
 
     do {
         if (ch == NM_KEY_QUESTION) {
             nm_lan_help();
         } else if (ch == NM_KEY_A) {
-            werase(action_window);
-            nm_init_action(_(NM_MSG_ADD_VETH));
-            werase(help_window);
-            nm_init_help_edit();
             nm_lan_add_veth();
             regen_data = 1;
             old_hl = veths_data.highlight;
@@ -173,13 +201,7 @@ void nm_lan_settings(void)
         }
 
         if (redraw_window) {
-            nm_destroy_windows();
-            endwin();
-            refresh();
-            nm_create_windows();
-            nm_init_help_lan();
-            nm_init_action(_(NM_MSG_LAN));
-            nm_init_side_lan();
+            nm_lan_init_main_windows(NULL);
 
             veth_list_len = (getmaxy(side_window) - 4);
             /* TODO save last pos */
@@ -205,31 +227,36 @@ void nm_lan_settings(void)
 
 static void nm_lan_add_veth(void)
 {
+    nm_form_data_t *form_data = NULL;
+    nm_form_t *form = NULL;
     nm_str_t l_name = NM_INIT_STR;
     nm_str_t r_name = NM_INIT_STR;
     nm_str_t query = NM_INIT_STR;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
-    nm_form_t *form = NULL;
-    size_t msg_len = nm_max_msg_len(nm_form_add_msg);
+    size_t msg_len;
 
-    if (nm_form_calc_size(msg_len, NM_LAN_FIELDS_NUM, &form_data) != NM_OK)
-        return;
+    nm_lan_init_add_windows(NULL);
 
-    for (size_t n = 0; n < NM_LAN_FIELDS_NUM; ++n)
-        fields[n] = new_field(1, form_data.form_len, n * 2, 0, 0, 0);
+    msg_len = nm_lan_labels_setup();
 
-    fields[NM_LAN_FIELDS_NUM] = NULL;
+    form_data = nm_form_data_new(
+        action_window, nm_lan_init_add_windows, msg_len, NM_LAN_FLD_COUNT / 2, NM_TRUE);
 
-    set_field_type(fields[NM_FLD_LNAME], TYPE_REGEXP, "^[a-zA-Z0-9_-]{1,15} *$");
-    set_field_type(fields[NM_FLD_RNAME], TYPE_REGEXP, "^[a-zA-Z0-9_-]{1,15} *$");
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
+        goto out;
 
-    for (size_t n = 0, y = 1, x = 2; n < NM_LAN_FIELDS_NUM; n++) {
-        mvwaddstr(form_data.form_window, y, x, nm_form_add_msg[n]);
-        y += 2;
+    for (size_t n = 0; n < NM_LAN_FLD_COUNT; n += 2) {
+        fields_lan[n] = nm_field_new(NM_FIELD_LABEL, n / 2, form_data);
+        fields_lan[n + 1] = nm_field_new(NM_FIELD_EDIT, n / 2, form_data);
     }
+    fields_lan[NM_LAN_FLD_COUNT] = NULL;
 
-    form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    if (nm_draw_form(action_window, form) != NM_OK)
+    nm_lan_labels_setup();
+    nm_lan_fields_setup();
+
+    form = nm_form_new(form_data, fields_lan);
+    nm_form_post(form);
+
+    if (nm_form_draw(&form) != NM_OK)
         goto out;
 
     if (nm_lan_add_get_data(&l_name, &r_name) != NM_OK)
@@ -246,21 +273,57 @@ out:
     wtimeout(action_window, -1);
     werase(help_window);
     nm_init_help_lan();
-    nm_form_free(form, fields);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields_lan);
     nm_str_free(&l_name);
     nm_str_free(&r_name);
     nm_str_free(&query);
 }
 
+static void nm_lan_fields_setup()
+{
+    set_field_type(fields_lan[NM_LAN_FLD_LNAME], TYPE_REGEXP, "^[a-zA-Z0-9_-]{1,15} *$");
+    set_field_type(fields_lan[NM_LAN_FLD_RNAME], TYPE_REGEXP, "^[a-zA-Z0-9_-]{1,15} *$");
+}
+
+static size_t nm_lan_labels_setup()
+{
+    nm_str_t buf = NM_INIT_STR;
+    size_t max_label_len = 0;
+
+    for (size_t n = 0; n < NM_LAN_FLD_COUNT; n++) {
+        switch (n) {
+        case NM_LAN_LBL_LNAME:
+            nm_str_format(&buf, "%s", _(NM_LAN_FORM_LNAME));
+            break;
+        case NM_LAN_LBL_RNAME:
+            nm_str_format(&buf, "%s", _(NM_LAN_FORM_RNAME));
+            break;
+        default:
+            continue;
+        }
+
+        if (buf.len > max_label_len)
+            max_label_len = buf.len;
+
+        if (fields_lan[n])
+            set_field_buffer(fields_lan[n], 0, buf.data);
+    }
+
+    nm_str_free(&buf);
+    return max_label_len;
+}
+
 static int nm_lan_add_get_data(nm_str_t *ln, nm_str_t *rn)
 {
-    int rc = NM_OK;
+    int rc;
     nm_str_t query = NM_INIT_STR;
     nm_vect_t err = NM_INIT_VECT;
     nm_vect_t names = NM_INIT_VECT;
 
-    nm_get_field_buf(fields[NM_FLD_LNAME], ln);
-    nm_get_field_buf(fields[NM_FLD_RNAME], rn);
+    nm_get_field_buf(fields_lan[NM_LAN_FLD_LNAME], ln);
+    nm_get_field_buf(fields_lan[NM_LAN_FLD_RNAME], rn);
 
     nm_form_check_datap(_("Name"), ln, err);
     nm_form_check_datap(_("Peer name"), rn, err);
@@ -455,69 +518,67 @@ void nm_lan_create_veth(int info)
 }
 
 #if defined (NM_WITH_NETWORK_MAP)
+static void nm_svg_init_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
+
+    nm_init_help_export();
+    nm_init_action(_(NM_MSG_EXPORT_MAP));
+    nm_init_side_if_list();
+
+    nm_print_veth_menu(NULL, 1);
+}
+
 static void nm_lan_export_svg(const nm_vect_t *veths)
 {
+    nm_form_data_t *form_data = NULL;
     nm_form_t *form = NULL;
-    nm_field_t *sfields[NM_SVG_FIELDS_NUM + 1] = {NULL};
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
     nm_vect_t err = NM_INIT_VECT;
-    nm_vect_t vgroup = NM_INIT_VECT;
     nm_str_t path = NM_INIT_STR;
     nm_str_t type = NM_INIT_STR;
     nm_str_t layout = NM_INIT_STR;
     nm_str_t group = NM_INIT_STR;
     int state = NM_SVG_STATE_ALL;
-    size_t msg_len = nm_max_msg_len(nm_form_svg_msg);
     char **states = (char **) nm_form_svg_state;
-    const char **groups;
+    size_t msg_len;
 
-    if (nm_form_calc_size(msg_len, NM_SVG_FIELDS_NUM, &form_data) != NM_OK)
-        return;
+    nm_svg_init_windows(NULL);
 
-    for (size_t n = 0; n < NM_SVG_FIELDS_NUM; ++n)
-        sfields[n] = new_field(1, form_data.form_len, n * 2, 0, 0, 0);
+    msg_len = nm_svg_labels_setup();
 
-    nm_db_select(NM_GET_GROUPS_SQL, &vgroup);
-    groups = nm_calloc(vgroup.n_memb + 1, sizeof(char *));
-    for (size_t n = 0; n < vgroup.n_memb; n++) {
-       groups[n] = nm_vect_str_ctx(&vgroup, n);
-    }
-    groups[vgroup.n_memb] = NULL;
+    form_data = nm_form_data_new(
+        action_window, nm_svg_init_windows, msg_len, NM_SVG_FLD_COUNT / 2, NM_TRUE);
 
-    sfields[NM_SVG_FIELDS_NUM] = NULL;
-
-    set_field_type(sfields[NM_SVG_FLD_PATH], TYPE_REGEXP, "^/.*");
-    set_field_type(sfields[NM_SVG_FLD_TYPE], TYPE_ENUM, nm_form_svg_state, false, false);
-    set_field_type(sfields[NM_SVG_FLD_LAYT], TYPE_ENUM, nm_form_svg_layout, false, false);
-    set_field_type(sfields[NM_SVG_FLD_GROUP], TYPE_ENUM, groups, false, false);
-    set_field_buffer(sfields[NM_SVG_FLD_TYPE], 0, nm_form_svg_state[0]);
-    set_field_buffer(sfields[NM_SVG_FLD_LAYT], 0, nm_form_svg_layout[0]);
-
-    if (vgroup.n_memb == 1) {
-        field_opts_off(sfields[NM_SVG_FLD_GROUP], O_ACTIVE);
-    }
-
-    werase(action_window);
-    werase(help_window);
-    nm_init_action(_(NM_MSG_EXPORT_MAP));
-    nm_init_help_export();
-
-    for (size_t n = 0, y = 1, x = 2; n < NM_SVG_FIELDS_NUM; n++) {
-        mvwaddstr(form_data.form_window, y, x, nm_form_svg_msg[n]);
-        y += 2;
-    }
-
-    form = nm_post_form(form_data.form_window, sfields, msg_len + 4, NM_TRUE);
-    if (nm_draw_form(action_window, form) != NM_OK)
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
         goto out;
 
-    nm_get_field_buf(sfields[NM_SVG_FLD_PATH], &path);
-    nm_get_field_buf(sfields[NM_SVG_FLD_TYPE], &type);
-    nm_get_field_buf(sfields[NM_SVG_FLD_LAYT], &layout);
-    nm_get_field_buf(sfields[NM_SVG_FLD_GROUP], &group);
-    nm_form_check_data(_(nm_form_svg_msg[NM_SVG_FLD_PATH]), path, err);
-    nm_form_check_data(_(nm_form_svg_msg[NM_SVG_FLD_TYPE]), type, err);
-    nm_form_check_data(_(nm_form_svg_msg[NM_SVG_FLD_LAYT]), layout, err);
+    for (size_t n = 0; n < NM_SVG_FLD_COUNT; n += 2) {
+        fields_svg[n] = nm_field_new(NM_FIELD_LABEL, n / 2, form_data);
+        fields_svg[n + 1] = nm_field_new(NM_FIELD_EDIT, n / 2, form_data);
+    }
+    fields_svg[NM_SVG_FLD_COUNT] = NULL;
+
+    nm_svg_labels_setup();
+    nm_svg_fields_setup();
+
+    form = nm_form_new(form_data, fields_svg);
+    nm_form_post(form);
+
+    if (nm_form_draw(&form) != NM_OK)
+        goto out;
+
+    nm_get_field_buf(fields_svg[NM_SVG_FLD_PATH], &path);
+    nm_get_field_buf(fields_svg[NM_SVG_FLD_TYPE], &type);
+    nm_get_field_buf(fields_svg[NM_SVG_FLD_LAYT], &layout);
+    nm_get_field_buf(fields_svg[NM_SVG_FLD_GROUP], &group);
+    nm_form_check_data(_(NM_SVG_FORM_PATH), path, err);
+    nm_form_check_data(_(NM_SVG_FORM_TYPE), type, err);
+    nm_form_check_data(_(NM_SVG_FORM_LAYT), layout, err);
 
     if (nm_print_empty_fields(&err) == NM_ERR) {
         nm_vect_free(&err, NULL);
@@ -542,11 +603,72 @@ out:
     nm_str_free(&type);
     nm_str_free(&layout);
     nm_str_free(&group);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields_svg);
+}
+
+static void nm_svg_fields_setup()
+{
+    nm_vect_t vgroup = NM_INIT_VECT;
+    const char **groups;
+
+    nm_db_select(NM_GET_GROUPS_SQL, &vgroup);
+    groups = nm_calloc(vgroup.n_memb + 1, sizeof(char *));
+    for (size_t n = 0; n < vgroup.n_memb; n++) {
+       groups[n] = nm_vect_str_ctx(&vgroup, n);
+    }
+    groups[vgroup.n_memb] = NULL;
+
+    set_field_type(fields_svg[NM_SVG_FLD_PATH], TYPE_REGEXP, "^/.*");
+    set_field_type(fields_svg[NM_SVG_FLD_TYPE], TYPE_ENUM, nm_form_svg_state, false, false);
+    set_field_type(fields_svg[NM_SVG_FLD_LAYT], TYPE_ENUM, nm_form_svg_layout, false, false);
+    set_field_type(fields_svg[NM_SVG_FLD_GROUP], TYPE_ENUM, groups, false, false);
+    set_field_buffer(fields_svg[NM_SVG_FLD_TYPE], 0, nm_form_svg_state[0]);
+    set_field_buffer(fields_svg[NM_SVG_FLD_LAYT], 0, nm_form_svg_layout[0]);
+
+    if (vgroup.n_memb == 1) {
+        field_opts_off(fields_svg[NM_SVG_FLD_GROUP], O_ACTIVE);
+    }
+
     free(groups);
     nm_vect_free(&vgroup, nm_str_vect_free_cb);
-    nm_form_free(form, sfields);
-    delwin(form_data.form_window);
 }
+
+static size_t nm_svg_labels_setup()
+{
+    nm_str_t buf = NM_INIT_STR;
+    size_t max_label_len = 0;
+
+    for (size_t n = 0; n < NM_SVG_FLD_COUNT; n++) {
+        switch (n) {
+        case NM_SVG_LBL_PATH:
+            nm_str_format(&buf, "%s", _(NM_SVG_FORM_PATH));
+            break;
+        case NM_SVG_LBL_TYPE:
+            nm_str_format(&buf, "%s", _(NM_SVG_FORM_TYPE));
+            break;
+        case NM_SVG_LBL_LAYT:
+            nm_str_format(&buf, "%s", _(NM_SVG_FORM_LAYT));
+            break;
+        case NM_SVG_LBL_GROUP:
+            nm_str_format(&buf, "%s", _(NM_SVG_FORM_GROUP));
+            break;
+        default:
+            continue;
+        }
+
+        if (buf.len > max_label_len)
+            max_label_len = buf.len;
+
+        if (fields_svg[n])
+            set_field_buffer(fields_svg[n], 0, buf.data);
+    }
+
+    nm_str_free(&buf);
+    return max_label_len;
+}
+
 #endif /* NM_WITH_NETWORK_MAP */
 #endif /* NM_OS_LINUX */
 /* vim:set ts=4 sw=4: */

--- a/src/nm_main_loop.c
+++ b/src/nm_main_loop.c
@@ -566,6 +566,7 @@ static size_t nm_search_vm(const nm_vect_t *list, int *err, nm_filter_t *filter)
     set_field_back(fields[1], A_UNDERLINE);
     field_opts_off(fields[1], O_STATIC);
     set_field_buffer(fields[0], 0, _(NM_SEARCH_STR));
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_main_loop.c
+++ b/src/nm_main_loop.c
@@ -605,6 +605,7 @@ static size_t nm_search_vm(const nm_vect_t *list, int *err, nm_filter_t *filter)
 
 out:
     nm_form_free(form);
+    nm_form_data_free(form_data);
     nm_fields_free(fields);
     nm_str_free(&input);
 

--- a/src/nm_main_loop.c
+++ b/src/nm_main_loop.c
@@ -509,44 +509,71 @@ void nm_start_main_loop(void)
     nm_vect_free(&vm_list, nm_str_vect_free_cb);
 }
 
+static void nm_search_init_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = side_window;
+    }
+
+    nm_init_side();
+    nm_init_action(NULL);
+    nm_init_help_main();
+
+    nm_print_vm_menu(NULL);
+    nm_print_vm_info(NULL, NULL, 0);
+    wrefresh(action_window);
+    wrefresh(side_window);
+}
+
 static size_t nm_search_vm(const nm_vect_t *list, int *err, nm_filter_t *filter)
 {
     if (!err)
         return 0;
 
+    nm_form_data_t *form_data = NULL;
+    nm_form_t *form = NULL;
+    nm_field_t *fields[3] = {NULL};
     size_t pos = 0;
     void *match = NULL;
-    nm_form_t *form = NULL;
-    nm_field_t *fields[2];
     nm_str_t input = NM_INIT_STR;
-    int cols = getmaxx(side_window);
     size_t msg_len = mbstowcs(NULL, _(NM_SEARCH_STR), strlen(NM_SEARCH_STR));
-    int req_len = msg_len + 9;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
 
-    if (req_len > cols) {
-        *err = NM_TRUE;
-        return 0;
-    }
+    nm_search_init_windows(NULL);
 
     wattroff(side_window, COLOR_PAIR(NM_COLOR_HIGHLIGHT));
-
-    form_data.form_len = cols - (5 + msg_len);
-    form_data.w_start_x = msg_len + 2;
-
-    fields[0] = new_field(1, form_data.form_len, 0, 1, 0, 0);
-    fields[1] = NULL;
-    set_field_back(fields[0], A_UNDERLINE);
-    field_opts_off(fields[0], O_STATIC);
-    NM_ERASE_TITLE(side, cols);
-    mvwaddstr(side_window, 1, 2, _(NM_SEARCH_STR));
+    NM_ERASE_TITLE(side, getmaxx(side_window));
     wrefresh(side_window);
 
-    form = nm_post_form(side_window, fields, form_data.w_start_x, NM_FALSE);
-    if (nm_draw_form(side_window, form) != NM_OK)
+    form_data = nm_form_data_new(
+        side_window, nm_search_init_windows, msg_len, 1, NM_FALSE);
+
+    form_data->field_vpad = 0;
+    form_data->field_hpad = 1;
+    form_data->form_ratio = 0.99;
+    form_data->form_vpad = 0;
+    form_data->w_start_y = 1;
+
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
         goto out;
 
-    nm_get_field_buf(fields[0], &input);
+    fields[0] = nm_field_new(NM_FIELD_LABEL, 0, form_data);
+    fields[1] = nm_field_new(NM_FIELD_EDIT, 0, form_data);
+    fields[2] = NULL;
+
+    set_field_back(fields[1], A_UNDERLINE);
+    field_opts_off(fields[1], O_STATIC);
+    set_field_buffer(fields[0], 0, _(NM_SEARCH_STR));
+
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
+
+    if (nm_form_draw(&form) != NM_OK)
+        goto out;
+
+    nm_get_field_buf(fields[1], &input);
     if (!input.len)
         goto out;
 
@@ -577,7 +604,8 @@ static size_t nm_search_vm(const nm_vect_t *list, int *err, nm_filter_t *filter)
     }
 
 out:
-    nm_form_free(form, fields);
+    nm_form_free(form);
+    nm_fields_free(fields);
     nm_str_free(&input);
 
     return pos;
@@ -585,22 +613,19 @@ out:
 
 static int nm_filter_check(const nm_str_t *input, nm_filter_t *filter)
 {
-    if (input->len <= 2)
+    if (input->len < 2)
         return NM_ERR;
 
-    if (input->data[1] != ':')
+    if (input->data[0] != 'g' && input->data[1] != ':')
         return NM_ERR;
 
-    if (input->data[0] == 'g') {
-        nm_str_format(&filter->query, "%s", input->data + 2);
-        if (nm_str_cmp_st(&filter->query, "all") == NM_OK) {
-            filter->flags |= NM_FILTER_RESET;
-            return NM_OK;
-        }
-
-        filter->type = NM_FILTER_GROUP;
+    if (input->len == 2) {
+        filter->flags |= NM_FILTER_RESET;
+        return NM_OK;
     }
 
+    nm_str_format(&filter->query, "%s", input->data + 2);
+    filter->type = NM_FILTER_GROUP;
     filter->flags |= NM_FILTER_UPDATE;
 
     return NM_OK;

--- a/src/nm_menu.c
+++ b/src/nm_menu.c
@@ -36,6 +36,13 @@ void nm_print_base_menu(nm_menu_data_t *ifs)
 {
     int x = 2, y = 3;
     size_t screen_x;
+    static nm_menu_data_t *ifs_ = NULL;
+
+    if (ifs)
+        ifs_ = ifs;
+
+    if (!ifs_)
+        return;
 
     wattroff(side_window, COLOR_PAIR(NM_COLOR_HIGHLIGHT));
 
@@ -46,14 +53,14 @@ void nm_print_base_menu(nm_menu_data_t *ifs)
         return;
     }
 
-    for (size_t n = ifs->item_first, i = 0; n < ifs->item_last; n++, i++) {
+    for (size_t n = ifs_->item_first, i = 0; n < ifs_->item_last; n++, i++) {
         nm_str_t if_name = NM_INIT_STR;
         int space_num;
 
-        if (n >= ifs->v->n_memb)
+        if (n >= ifs_->v->n_memb)
             nm_bug(_("%s: invalid index: %zu"), __func__, n);
 
-        nm_str_alloc_text(&if_name, (char *) ifs->v->data[n]);
+        nm_str_alloc_text(&if_name, (char *) ifs_->v->data[n]);
         nm_align2line(&if_name, screen_x);
 
         space_num = (screen_x - if_name.len - 4);
@@ -62,7 +69,7 @@ void nm_print_base_menu(nm_menu_data_t *ifs)
                 nm_str_add_char_opt(&if_name, ' ');
         }
 
-        if (ifs->highlight == i + 1) {
+        if (ifs_->highlight == i + 1) {
             wattron(side_window, A_REVERSE);
             mvwprintw(side_window, y, x, "%s", if_name.data);
             wattroff(side_window, A_REVERSE);
@@ -80,6 +87,13 @@ void nm_print_vm_menu(nm_menu_data_t *vm)
 {
     int x = 2, y = 3;
     size_t screen_x;
+    static nm_menu_data_t *vm_ = NULL;
+
+    if (vm)
+        vm_ = vm;
+
+    if(!vm_)
+        return;
 
     screen_x = getmaxx(side_window);
     if (screen_x < 20) { /* window to small */
@@ -90,14 +104,14 @@ void nm_print_vm_menu(nm_menu_data_t *vm)
 
     wattroff(side_window, COLOR_PAIR(NM_COLOR_HIGHLIGHT));
 
-    for (size_t n = vm->item_first, i = 0; n < vm->item_last; n++, i++) {
+    for (size_t n = vm_->item_first, i = 0; n < vm_->item_last; n++, i++) {
         int space_num;
         nm_str_t vm_name = NM_INIT_STR;
 
-        if (n >= vm->v->n_memb)
+        if (n >= vm_->v->n_memb)
             nm_bug(_("%s: invalid index: %zu"), __func__, n);
 
-        nm_str_alloc_text(&vm_name, nm_vect_item_name_ctx(vm->v, n));
+        nm_str_alloc_text(&vm_name, nm_vect_item_name_ctx(vm_->v, n));
         nm_align2line(&vm_name, screen_x);
 
         space_num = (screen_x - vm_name.len - 4);
@@ -106,15 +120,15 @@ void nm_print_vm_menu(nm_menu_data_t *vm)
                 nm_str_add_char_opt(&vm_name, ' ');
         }
 
-        if (nm_qmp_test_socket(nm_vect_item_name(vm->v, n)) == NM_OK) {
-            nm_vect_set_item_status(vm->v, n, 1);
+        if (nm_qmp_test_socket(nm_vect_item_name(vm_->v, n)) == NM_OK) {
+            nm_vect_set_item_status(vm_->v, n, 1);
             wattron(side_window, COLOR_PAIR(NM_COLOR_HIGHLIGHT));
         } else {
-            nm_vect_set_item_status(vm->v, n, 0);
+            nm_vect_set_item_status(vm_->v, n, 0);
             wattroff(side_window, COLOR_PAIR(NM_COLOR_HIGHLIGHT));
         }
 
-        if (vm->highlight == i + 1) {
+        if (vm_->highlight == i + 1) {
             wattron(side_window, A_REVERSE);
             mvwprintw(side_window, y, x, "%s", vm_name.data);
             wattroff(side_window, A_REVERSE);
@@ -181,6 +195,13 @@ void nm_print_veth_menu(nm_menu_data_t *veth, int get_status)
     nm_str_t veth_copy = NM_INIT_STR;
     nm_str_t veth_lname = NM_INIT_STR;
     nm_str_t veth_rname = NM_INIT_STR;
+    static nm_menu_data_t *veth_ = NULL;
+
+    if (veth)
+        veth_ = veth;
+
+    if (!veth_)
+        return;
 
     screen_x = getmaxx(side_window);
     if (screen_x < 20) { /* window to small */
@@ -191,13 +212,13 @@ void nm_print_veth_menu(nm_menu_data_t *veth, int get_status)
 
     wattroff(side_window, COLOR_PAIR(NM_COLOR_HIGHLIGHT));
 
-    for (size_t n = veth->item_first, i = 0; n < veth->item_last; n++, i++) {
+    for (size_t n = veth_->item_first, i = 0; n < veth_->item_last; n++, i++) {
         int space_num;
 
-        if (n >= veth->v->n_memb)
+        if (n >= veth_->v->n_memb)
             nm_bug(_("%s: invalid index: %zu"), __func__, n);
 
-        nm_str_alloc_text(&veth_name, nm_vect_item_name_ctx(veth->v, n));
+        nm_str_alloc_text(&veth_name, nm_vect_item_name_ctx(veth_->v, n));
         nm_str_copy(&veth_copy, &veth_name);
         nm_align2line(&veth_name, screen_x);
         nm_lan_parse_name(&veth_copy, &veth_lname, &veth_rname);
@@ -210,17 +231,17 @@ void nm_print_veth_menu(nm_menu_data_t *veth, int get_status)
 
         if (get_status) {
             if (nm_net_link_status(&veth_lname) == NM_OK)
-                nm_vect_set_item_status(veth->v, n, 1);
+                nm_vect_set_item_status(veth_->v, n, 1);
             else
-                nm_vect_set_item_status(veth->v, n, 0);
+                nm_vect_set_item_status(veth_->v, n, 0);
         }
 
-        if (nm_vect_item_status(veth->v, n))
+        if (nm_vect_item_status(veth_->v, n))
             wattron(side_window, COLOR_PAIR(NM_COLOR_HIGHLIGHT));
         else
             wattroff(side_window, COLOR_PAIR(NM_COLOR_HIGHLIGHT));
 
-        if (veth->highlight == i + 1) {
+        if (veth_->highlight == i + 1) {
             wattron(side_window, A_REVERSE);
             mvwprintw(side_window, y, x, "%s", veth_name.data);
             wattroff(side_window, A_REVERSE);

--- a/src/nm_ovf_import.c
+++ b/src/nm_ovf_import.c
@@ -6,6 +6,7 @@
 #include <nm_string.h>
 #include <nm_vector.h>
 #include <nm_window.h>
+#include <nm_menu.h>
 #include <nm_add_vm.h>
 #include <nm_cfg_file.h>
 #include <nm_ovf_import.h>
@@ -86,19 +87,6 @@ static const char NM_XPATH_USB_EHCI[] = \
     "/ovf:Envelope/ovf:VirtualSystem/ovf:VirtualHardwareSection/" \
     "ovf:Item[rasd:ResourceType/text()=23]";
 
-enum {
-    NM_OVA_FLD_SRC = 0,
-    NM_OVA_FLD_ARCH,
-    NM_OVA_FLD_NAME,
-    NM_OVA_FLD_VER,
-    NM_OVA_FLD_COUNT
-};
-
-static const char *nm_form_msg[] = {
-    NM_OVF_FORM_PATH, NM_OVF_FORM_ARCH,
-    NM_OVF_FORM_NAME, NM_OVF_FORM_VER, NULL
-};
-
 typedef struct archive nm_archive_t;
 typedef struct archive_entry nm_archive_entry_t;
 
@@ -112,6 +100,9 @@ typedef xmlXPathContextPtr nm_xml_xpath_ctx_pt;
 void nm_drive_vect_ins_cb(void *unit_p, const void *ctx);
 void nm_drive_vect_free_cb(void *unit_p);
 
+static void nm_ovf_init_windows(nm_form_t *form);
+static void nm_ovf_fields_setup();
+static size_t nm_ovf_labels_setup();
 static int nm_clean_temp_dir(const char *tmp_dir, const nm_vect_t *files);
 static void nm_archive_copy_data(nm_archive_t *in, nm_archive_t *out);
 static void nm_ovf_extract(const nm_str_t *ova_path, const char *tmp_dir,
@@ -138,10 +129,36 @@ static void nm_ovf_convert_drives(const nm_vect_t *drives, const nm_str_t *name,
 static void nm_ovf_to_db(nm_vm_t *vm, const nm_vect_t *drives);
 static int nm_ova_get_data(nm_vm_t *vm, int *version);
 
-static nm_field_t *fields[NM_OVA_FLD_COUNT + 1];
+enum {
+    NM_OVA_LBL_SRC = 0, NM_OVA_FLD_SRC,
+    NM_OVA_LBL_ARCH, NM_OVA_FLD_ARCH,
+    NM_OVA_LBL_NAME, NM_OVA_FLD_NAME,
+    NM_OVA_LBL_VER, NM_OVA_FLD_VER,
+    NM_FLD_COUNT
+};
+
+static nm_field_t *fields[NM_FLD_COUNT + 1];
+
+static void nm_ovf_init_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
+
+    nm_init_side();
+    nm_init_action(_(NM_MSG_OVA_HEADER));
+    nm_init_help_import();
+
+    nm_print_vm_menu(NULL);
+}
 
 void nm_ovf_import(void)
 {
+    nm_form_data_t *form_data = NULL;
+    nm_form_t *form = NULL;
     char templ_path[sizeof(NM_OVA_DIR_TEMPL)];
     const char *ovf_file;
     nm_vect_t files = NM_INIT_VECT;
@@ -149,49 +166,36 @@ void nm_ovf_import(void)
     nm_vm_t vm = NM_INIT_VM;
     nm_xml_doc_pt doc = NULL;
     nm_xml_xpath_ctx_pt xpath_ctx = NULL;
-    nm_form_t *form = NULL;
     nm_spinner_data_t sp_data = NM_INIT_SPINNER;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
     size_t msg_len;
     pthread_t spin_th;
     int done = 0, version = 0;
 
     strncpy(templ_path, NM_OVA_DIR_TEMPL, sizeof(templ_path));
 
-    msg_len = nm_max_msg_len(nm_form_msg);
+    nm_ovf_init_windows(NULL);
 
-    if (nm_form_calc_size(msg_len, NM_OVA_FLD_COUNT, &form_data) != NM_OK)
-        return;
+    msg_len = nm_ovf_labels_setup();
 
-    werase(action_window);
-    werase(help_window);
-    nm_init_action(_(NM_MSG_OVA_HEADER));
-    nm_init_help_import();
+    form_data = nm_form_data_new(
+        action_window, nm_ovf_init_windows, msg_len, NM_FLD_COUNT / 2, NM_TRUE);
 
-    for (size_t n = 0; n < NM_OVA_FLD_COUNT; ++n)
-        fields[n] = new_field(1, form_data.form_len, n * 2, 0, 0, 0);
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
+        goto out;
 
-    fields[NM_OVA_FLD_COUNT] = NULL;
-
-    set_field_type(fields[NM_OVA_FLD_SRC], TYPE_REGEXP, "^/.*");
-    set_field_type(fields[NM_OVA_FLD_ARCH], TYPE_ENUM,
-                   nm_cfg_get_arch(), false, false);
-    set_field_type(fields[NM_OVA_FLD_NAME], TYPE_REGEXP,
-                   "^[a-zA-Z0-9_-]{1,30} *$");
-    set_field_type(fields[NM_OVA_FLD_VER], TYPE_ENUM,
-                   nm_ovf_version, false, false);
-    set_field_buffer(fields[NM_OVA_FLD_ARCH], 0, *nm_cfg_get()->qemu_targets.data);
-    set_field_buffer(fields[NM_OVA_FLD_VER], 0, *nm_ovf_version);
-    field_opts_off(fields[NM_OVA_FLD_SRC], O_STATIC);
-    field_opts_off(fields[NM_OVA_FLD_NAME], O_STATIC);
-
-    for (size_t n = 0, y = 1, x = 2; n < NM_OVA_FLD_COUNT; n++) {
-        mvwaddstr(form_data.form_window, y, x, _(nm_form_msg[n]));
-        y += 2;
+    for (size_t n = 0; n < NM_FLD_COUNT; n += 2) {
+        fields[n] = nm_field_new(NM_FIELD_LABEL, n / 2, form_data);
+        fields[n + 1] = nm_field_new(NM_FIELD_EDIT, n / 2, form_data);
     }
+    fields[NM_FLD_COUNT] = NULL;
 
-    form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    if (nm_draw_form(action_window, form) != NM_OK)
+    nm_ovf_labels_setup();
+    nm_ovf_fields_setup();
+
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
+
+    if (nm_form_draw(&form) != NM_OK)
         goto cancel;
 
     if (nm_ova_get_data(&vm, &version) != NM_OK)
@@ -261,9 +265,59 @@ out:
 
 cancel:
     NM_FORM_EXIT();
-    nm_form_free(form, fields);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields);
     nm_vm_free(&vm);
-    delwin(form_data.form_window);
+}
+
+static void nm_ovf_fields_setup()
+{
+    set_field_type(fields[NM_OVA_FLD_SRC], TYPE_REGEXP, "^/.*");
+    set_field_type(fields[NM_OVA_FLD_ARCH], TYPE_ENUM,
+                   nm_cfg_get_arch(), false, false);
+    set_field_type(fields[NM_OVA_FLD_NAME], TYPE_REGEXP,
+                   "^[a-zA-Z0-9_-]{1,30} *$");
+    set_field_type(fields[NM_OVA_FLD_VER], TYPE_ENUM,
+                   nm_ovf_version, false, false);
+    set_field_buffer(fields[NM_OVA_FLD_ARCH], 0, *nm_cfg_get()->qemu_targets.data);
+    set_field_buffer(fields[NM_OVA_FLD_VER], 0, *nm_ovf_version);
+    field_opts_off(fields[NM_OVA_FLD_SRC], O_STATIC);
+    field_opts_off(fields[NM_OVA_FLD_NAME], O_STATIC);
+}
+
+static size_t nm_ovf_labels_setup()
+{
+    nm_str_t buf = NM_INIT_STR;
+    size_t max_label_len = 0;
+
+    for (size_t n = 0; n < NM_FLD_COUNT; n++) {
+        switch (n) {
+        case NM_OVA_LBL_SRC:
+            nm_str_format(&buf, "%s", _(NM_OVF_FORM_PATH));
+            break;
+        case NM_OVA_LBL_ARCH:
+            nm_str_format(&buf, "%s", _(NM_OVF_FORM_ARCH));
+            break;
+        case NM_OVA_LBL_NAME:
+            nm_str_format(&buf, "%s", _(NM_OVF_FORM_NAME));
+            break;
+        case NM_OVA_LBL_VER:
+            nm_str_format(&buf, "%s", _(NM_OVF_FORM_VER));
+            break;
+        default:
+            continue;
+        }
+
+        if (buf.len > max_label_len)
+            max_label_len = buf.len;
+
+        if (fields[n])
+            set_field_buffer(fields[n], 0, buf.data);
+    }
+
+    nm_str_free(&buf);
+    return max_label_len;
 }
 
 static void nm_ovf_extract(const nm_str_t *ova_path, const char *tmp_dir,
@@ -676,7 +730,7 @@ static void nm_ovf_to_db(nm_vm_t *vm, const nm_vect_t *drives)
 
 static int nm_ova_get_data(nm_vm_t *vm, int *version)
 {
-    int rc = NM_OK;
+    int rc;
     nm_vect_t err = NM_INIT_VECT;
     nm_str_t ver = NM_INIT_STR;
 

--- a/src/nm_ovf_import.c
+++ b/src/nm_ovf_import.c
@@ -290,6 +290,7 @@ static size_t nm_ovf_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
         switch (n) {
@@ -309,8 +310,9 @@ static size_t nm_ovf_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields[n])
             set_field_buffer(fields[n], 0, buf.data);

--- a/src/nm_ovf_import.c
+++ b/src/nm_ovf_import.c
@@ -191,6 +191,7 @@ void nm_ovf_import(void)
 
     nm_ovf_labels_setup();
     nm_ovf_fields_setup();
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_rename_vm.c
+++ b/src/nm_rename_vm.c
@@ -9,20 +9,37 @@
 
 static const char NM_RENAME_FORM_MSG[] = "New VM name";
 
-enum {
-    NM_FLD_NEWNAME = 0,
-    NM_FLD_COUNT
-};
-
+static void nm_rename_init_windows(nm_form_t *form);
 static void nm_rename_vm_in_db(const nm_vmctl_data_t *vm, const nm_str_t *new_name);
 static void nm_rename_vm_in_fs(const nm_vmctl_data_t *vm, const nm_str_t *new_name);
 
+enum {
+    NM_LBL_NEWNAME = 0, NM_FLD_NEWNAME,
+    NM_FLD_COUNT
+};
+
+static void nm_rename_init_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
+
+    nm_init_side();
+    nm_init_action(_(NM_MSG_RENAME_VM));
+    nm_init_help_edit();
+
+    nm_print_vm_menu(NULL);
+}
+
 void nm_rename_vm(const nm_str_t *name)
 {
+    nm_form_data_t *form_data = NULL;
     nm_form_t *form = NULL;
     nm_field_t *fields[NM_FLD_COUNT + 1] = {NULL};
     nm_vmctl_data_t vm = NM_VMCTL_INIT_DATA;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
     nm_str_t buf = NM_INIT_STR;
     nm_str_t new_name = NM_INIT_STR;
     nm_spinner_data_t sp_data = NM_INIT_SPINNER;
@@ -31,32 +48,34 @@ void nm_rename_vm(const nm_str_t *name)
     pthread_t spin_th;
     int done = 0;
 
-    msg_len = mbstowcs(NULL, _(NM_RENAME_FORM_MSG), strlen(_(NM_RENAME_FORM_MSG)));
-    if (nm_form_calc_size(msg_len, 1, &form_data) != NM_OK)
-        return;
-
-    werase(action_window);
-    werase(help_window);
-    nm_init_action(_(NM_MSG_RENAME_VM));
-    nm_init_help_edit();
+    nm_rename_init_windows(NULL);
 
     nm_vmctl_get_data(name, &vm);
 
-    fields[0] = new_field(1, form_data.form_len, 0, 0, 0, 0);
-    fields[1] = NULL;
+    msg_len = mbstowcs(NULL, _(NM_RENAME_FORM_MSG), strlen(_(NM_RENAME_FORM_MSG)));
 
-    set_field_type(fields[0], TYPE_REGEXP, "^[a-zA-Z0-9_-]{1,30} *$");
+    form_data = nm_form_data_new(
+        action_window, nm_rename_init_windows, msg_len, NM_FLD_COUNT / 2, NM_TRUE);
 
-    nm_str_format(&buf, "%s", name->data);
-    set_field_buffer(fields[0], 0, buf.data);
-
-    mvwaddstr(form_data.form_window, 1, 2, _(NM_RENAME_FORM_MSG));
-
-    form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    if (nm_draw_form(action_window, form) != NM_OK)
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
         goto out;
 
-    nm_get_field_buf(fields[0], &new_name);
+    fields[0] = nm_field_new(NM_FIELD_LABEL, 0, form_data);
+    fields[1] = nm_field_new(NM_FIELD_EDIT, 0, form_data);
+    fields[2] = NULL;
+
+    set_field_buffer(fields[0], 0, _(NM_MSG_RENAME_VM));
+    set_field_type(fields[1], TYPE_REGEXP, "^[a-zA-Z0-9_-]{1,30} *$");
+    nm_str_format(&buf, "%s", name->data);
+    set_field_buffer(fields[1], 0, buf.data);
+
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
+
+    if (nm_form_draw(&form) != NM_OK)
+        goto out;
+
+    nm_get_field_buf(fields[1], &new_name);
     nm_form_check_data(_(NM_RENAME_FORM_MSG), new_name, err);
 
     if (nm_print_empty_fields(&err) == NM_ERR) {
@@ -86,7 +105,9 @@ void nm_rename_vm(const nm_str_t *name)
 out:
     NM_FORM_EXIT();
     nm_vmctl_free_data(&vm);
-    nm_form_free(form, fields);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields);
     nm_str_free(&buf);
     nm_str_free(&new_name);
 }

--- a/src/nm_rename_vm.c
+++ b/src/nm_rename_vm.c
@@ -68,6 +68,7 @@ void nm_rename_vm(const nm_str_t *name)
     set_field_type(fields[1], TYPE_REGEXP, "^[a-zA-Z0-9_-]{1,30} *$");
     nm_str_format(&buf, "%s", name->data);
     set_field_buffer(fields[1], 0, buf.data);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_usb_plug.c
+++ b/src/nm_usb_plug.c
@@ -102,6 +102,7 @@ void nm_usb_plug(const nm_str_t *name, int vm_status)
     set_field_type(fields[1], TYPE_ENUM, usb_names.data, false, false);
     field_opts_off(fields[1], O_STATIC);
     set_field_buffer(fields[1], 0, *usb_names.data);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);
@@ -169,6 +170,7 @@ void nm_usb_unplug(const nm_str_t *name, int vm_status)
     set_field_type(fields[1], TYPE_ENUM, usb_names.data, false, false);
     field_opts_off(fields[1], O_STATIC);
     set_field_buffer(fields[1], 0, *usb_names.data);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_viewer.c
+++ b/src/nm_viewer.c
@@ -161,6 +161,7 @@ static size_t nm_viewer_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
         switch (n) {
@@ -188,8 +189,9 @@ static size_t nm_viewer_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields[n])
             set_field_buffer(fields[n], 0, buf.data);

--- a/src/nm_viewer.c
+++ b/src/nm_viewer.c
@@ -103,6 +103,7 @@ void nm_viewer(const nm_str_t *name)
 
     nm_viewer_labels_setup();
     nm_viewer_fields_setup(&vm);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_vm_snapshot.c
+++ b/src/nm_vm_snapshot.c
@@ -116,6 +116,7 @@ void nm_vm_snapshot_create(const nm_str_t *name)
 
     nm_vm_snapshot_create_labels_setup();
     nm_vm_snapshot_create_fields_setup();
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);
@@ -236,6 +237,7 @@ void nm_vm_snapshot_delete(const nm_str_t *name, int vm_status)
     set_field_buffer(fields[0], 0, _(NM_VMSNAP_FORM_SNAP));
     set_field_type(fields[1], TYPE_ENUM, choices.data, false, false);
     set_field_buffer(fields[1], 0, *choices.data);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);
@@ -325,6 +327,7 @@ void nm_vm_snapshot_load(const nm_str_t *name, int vm_status)
     set_field_buffer(fields[0], 0, _(NM_VMSNAP_FORM_SNAP));
     set_field_type(fields[1], TYPE_ENUM, choices.data, false, false);
     set_field_buffer(fields[1], 0, *choices.data);
+    nm_fields_unset_status(fields);
 
     form = nm_form_new(form_data, fields);
     nm_form_post(form);

--- a/src/nm_vm_snapshot.c
+++ b/src/nm_vm_snapshot.c
@@ -3,32 +3,11 @@
 #include <nm_utils.h>
 #include <nm_string.h>
 #include <nm_window.h>
+#include <nm_menu.h>
 #include <nm_database.h>
 #include <nm_cfg_file.h>
 #include <nm_qmp_control.h>
 #include <nm_vm_snapshot.h>
-
-static const char NM_FORMSTR_NAME[] = "Snapshot name";
-static const char NM_FORMSTR_LOAD[] = "Load at next boot";
-static const char NM_FORMSTR_SNAP[] = "Snapshot";
-
-enum {
-    NM_FLD_VMSNAPNAME = 0,
-    NM_FLD_VMLOAD,
-    NM_FLD_COUNT
-};
-
-static const char *nm_form_msg[] = {
-    NM_FORMSTR_NAME, NM_FORMSTR_LOAD, NULL
-};
-
-enum {
-    NM_SQL_VMSNAP_ID = 0,
-    NM_SQL_VMSNAP_VM,
-    NM_SQL_VMSNAP_NAME,
-    NM_SQL_VMSNAP_LOAD,
-    NM_SQL_VMSNAP_TIME
-};
 
 typedef struct {
     nm_str_t snap_name;
@@ -38,6 +17,16 @@ typedef struct {
 
 #define NM_INIT_VMSNAP (nm_vmsnap_t) { NM_INIT_STR, NM_INIT_STR, 0 }
 
+static const char NM_VMSNAP_FORM_NAME[] = "Snapshot name";
+static const char NM_VMSNAP_FORM_LOAD[] = "Load at next boot";
+static const char NM_VMSNAP_FORM_SNAP[] = "Snapshot";
+
+static void nm_vm_snapshot_init_windows(nm_form_t *form);
+static void nm_vm_snapshot_create_init_windows(nm_form_t *form);
+static void nm_vm_snapshot_revert_init_windows(nm_form_t *form);
+static void nm_vm_snapshot_delete_init_windows(nm_form_t *form);
+static void nm_vm_snapshot_create_fields_setup();
+static size_t nm_vm_snapshot_create_labels_setup();
 static int nm_vm_snapshot_get_data(const nm_str_t *name, nm_vmsnap_t *data);
 static void nm_vm_snapshot_to_db(const nm_str_t *name, const nm_vmsnap_t *data);
 static void __nm_vm_snapshot_load(const nm_str_t *name, const nm_str_t *snap,
@@ -45,41 +34,93 @@ static void __nm_vm_snapshot_load(const nm_str_t *name, const nm_str_t *snap,
 static void __nm_vm_snapshot_delete(const nm_str_t *name, const nm_str_t *snap,
                                     int vm_status);
 
+enum {
+    NM_SQL_VMSNAP_ID = 0,
+    NM_SQL_VMSNAP_VM,
+    NM_SQL_VMSNAP_NAME,
+    NM_SQL_VMSNAP_LOAD,
+    NM_SQL_VMSNAP_TIME
+};
+
+enum {
+    NM_LBL_VMSNAPNAME = 0, NM_FLD_VMSNAPNAME,
+    NM_LBL_VMLOAD, NM_FLD_VMLOAD,
+    NM_FLD_COUNT
+};
+
 static nm_field_t *fields[NM_FLD_COUNT + 1];
+static nm_vect_t snaps = NM_INIT_VECT;
+
+static void nm_vm_snapshot_init_windows(nm_form_t *form)
+{
+    nm_form_window_init();
+    if(form) {
+        nm_form_data_t *form_data = (nm_form_data_t *)form_userptr(form);
+        if(form_data)
+            form_data->parent_window = action_window;
+    }
+
+    nm_init_side();
+    nm_init_help_edit();
+
+    nm_print_vm_menu(NULL);
+}
+
+static void nm_vm_snapshot_create_init_windows(nm_form_t *form)
+{
+    nm_vm_snapshot_init_windows(form);
+    nm_init_action(_(NM_MSG_SNAP_CRT));
+}
+
+static void nm_vm_snapshot_revert_init_windows(nm_form_t *form)
+{
+    nm_vm_snapshot_init_windows(form);
+    nm_init_action(_(NM_MSG_SNAP_REV));
+    nm_print_snapshots(&snaps);
+}
+
+static void nm_vm_snapshot_delete_init_windows(nm_form_t *form)
+{
+    nm_vm_snapshot_init_windows(form);
+    nm_init_action(_(NM_MSG_SNAP_DEL));
+    nm_print_snapshots(&snaps);
+}
 
 void nm_vm_snapshot_create(const nm_str_t *name)
 {
+    nm_form_data_t *form_data = NULL;
     nm_form_t *form = NULL;
     nm_spinner_data_t sp_data = NM_INIT_SPINNER;
     nm_vmsnap_t data = NM_INIT_VMSNAP;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
     pthread_t spin_th;
     int done = 0;
-    size_t msg_len = nm_max_msg_len(nm_form_msg);
+    size_t msg_len;
 
-    if (nm_form_calc_size(msg_len, NM_FLD_COUNT, &form_data) != NM_OK)
-        return;
+    nm_vm_snapshot_create_init_windows(NULL);
 
-    werase(action_window);
-    werase(help_window);
-    nm_init_action(_(NM_MSG_SNAP_CRT));
-    nm_init_help_edit();
+    msg_len = nm_vm_snapshot_create_labels_setup();
 
-    for (size_t n = 0; n < NM_FLD_COUNT; ++n)
-        fields[n] = new_field(1, form_data.form_len, n * 2, 0, 0, 0);
+    form_data = nm_form_data_new(
+        action_window, nm_vm_snapshot_create_init_windows,
+        msg_len, NM_FLD_COUNT / 2, NM_TRUE
+    );
 
-    fields[NM_FLD_COUNT] = NULL;
-    field_opts_off(fields[NM_FLD_VMSNAPNAME], O_STATIC);
-    set_field_type(fields[NM_FLD_VMLOAD], TYPE_ENUM, nm_form_yes_no, false, false);
-    set_field_buffer(fields[NM_FLD_VMLOAD], 0, nm_form_yes_no[1]);
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
+        goto out;
 
-    for (size_t n = 0, y = 1, x = 2; n < NM_FLD_COUNT; n++) {
-        mvwaddstr(form_data.form_window, y, x, _(nm_form_msg[n]));
-        y += 2;
+    for (size_t n = 0; n < NM_FLD_COUNT; n += 2) {
+        fields[n] = nm_field_new(NM_FIELD_LABEL, n / 2, form_data);
+        fields[n + 1] = nm_field_new(NM_FIELD_EDIT, n / 2, form_data);
     }
+    fields[NM_FLD_COUNT] = NULL;
 
-    form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    if (nm_draw_form(action_window, form) != NM_OK)
+    nm_vm_snapshot_create_labels_setup();
+    nm_vm_snapshot_create_fields_setup();
+
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
+
+    if (nm_form_draw(&form) != NM_OK)
         goto out;
 
     if (nm_vm_snapshot_get_data(name, &data) != NM_OK)
@@ -99,25 +140,61 @@ void nm_vm_snapshot_create(const nm_str_t *name)
 
 out:
     NM_FORM_EXIT();
-    nm_form_free(form, fields);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields);
     nm_str_free(&data.snap_name);
     nm_str_free(&data.load);
 }
 
+static void nm_vm_snapshot_create_fields_setup()
+{
+    field_opts_off(fields[NM_FLD_VMSNAPNAME], O_STATIC);
+    set_field_type(fields[NM_FLD_VMLOAD], TYPE_ENUM, nm_form_yes_no, false, false);
+    set_field_buffer(fields[NM_FLD_VMLOAD], 0, nm_form_yes_no[1]);
+}
+
+static size_t nm_vm_snapshot_create_labels_setup()
+{
+    nm_str_t buf = NM_INIT_STR;
+    size_t max_label_len = 0;
+
+    for (size_t n = 0; n < NM_FLD_COUNT; n++) {
+        switch (n) {
+        case NM_LBL_VMSNAPNAME:
+            nm_str_format(&buf, "%s", _(NM_VMSNAP_FORM_NAME));
+            break;
+        case NM_LBL_VMLOAD:
+            nm_str_format(&buf, "%s", _(NM_VMSNAP_FORM_LOAD));
+            break;
+        default:
+            continue;
+        }
+
+        if (buf.len > max_label_len)
+            max_label_len = buf.len;
+
+        if (fields[n])
+            set_field_buffer(fields[n], 0, buf.data);
+    }
+
+    nm_str_free(&buf);
+    return max_label_len;
+}
+
 void nm_vm_snapshot_delete(const nm_str_t *name, int vm_status)
 {
+    nm_form_data_t *form_data = NULL;
     nm_form_t *form = NULL;
     nm_vect_t err = NM_INIT_VECT;
     nm_str_t query = NM_INIT_STR;
     nm_str_t buf = NM_INIT_STR;
-    nm_vect_t snaps = NM_INIT_VECT;
     nm_vect_t choices = NM_INIT_VECT;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
     nm_spinner_data_t sp_data = NM_INIT_SPINNER;
     int done = 0;
     pthread_t spin_th;
     size_t snaps_count = 0;
-    size_t msg_len = mbstowcs(NULL, _(NM_FORMSTR_SNAP), strlen(_(NM_FORMSTR_SNAP)));
+    size_t msg_len;
 
     nm_str_format(&query, NM_GET_SNAPS_ALL_SQL, name->data);
     nm_db_select(query.data, &snaps);
@@ -126,16 +203,6 @@ void nm_vm_snapshot_delete(const nm_str_t *name, int vm_status)
         nm_warn(_(NM_MSG_NO_SNAPS));
         goto out;
     }
-
-    if (nm_form_calc_size(msg_len, 1, &form_data) != NM_OK)
-        goto out;
-
-    werase(action_window);
-    werase(help_window);
-    nm_init_action(_(NM_MSG_SNAP_DEL));
-    nm_init_help_edit();
-
-    nm_print_snapshots(&snaps);
 
     snaps_count = snaps.n_memb / 5;
     for (size_t n = 0; n < snaps_count; n++) {
@@ -146,28 +213,40 @@ void nm_vm_snapshot_delete(const nm_str_t *name, int vm_status)
             nm_vect_str_len(&snaps, NM_SQL_VMSNAP_NAME + idx_shift) + 1,
             NULL);
     }
-
     nm_vect_end_zero(&choices);
 
-    fields[0] = new_field(1, form_data.form_len, 0, 0, 0, 0);
-    fields[1] = NULL;
+    nm_vm_snapshot_delete_init_windows(NULL);
 
-    set_field_type(fields[0], TYPE_ENUM, choices.data, false, false);
-    set_field_buffer(fields[0], 0, *choices.data);
+    msg_len = mbstowcs(NULL, _(NM_VMSNAP_FORM_SNAP), strlen(_(NM_VMSNAP_FORM_SNAP)));
 
-    mvwaddstr(form_data.form_window, 1, 2, _(NM_FORMSTR_SNAP));
+    form_data = nm_form_data_new(
+        action_window, nm_vm_snapshot_delete_init_windows,
+        msg_len, 1, NM_TRUE
+    );
 
-    form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    curs_set(0);
-    if (nm_draw_form(action_window, form) != NM_OK)
-        goto clean_and_out;
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
+        goto out;
 
-    nm_get_field_buf(fields[0], &buf);
-    nm_form_check_data(_(NM_FORMSTR_SNAP), buf, err);
+    fields[0] = nm_field_new(NM_FIELD_LABEL, 0, form_data);
+    fields[1] = nm_field_new(NM_FIELD_EDIT, 0, form_data);
+    fields[2] = NULL;
+
+    set_field_buffer(fields[0], 0, _(NM_VMSNAP_FORM_SNAP));
+    set_field_type(fields[1], TYPE_ENUM, choices.data, false, false);
+    set_field_buffer(fields[1], 0, *choices.data);
+
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
+
+    if (nm_form_draw(&form) != NM_OK)
+        goto out;
+
+    nm_get_field_buf(fields[1], &buf);
+    nm_form_check_data(_(NM_VMSNAP_FORM_SNAP), buf, err);
 
     if (nm_print_empty_fields(&err) == NM_ERR) {
         nm_vect_free(&err, NULL);
-        goto clean_and_out;
+        goto out;
     }
 
     sp_data.stop = &done;
@@ -181,34 +260,30 @@ void nm_vm_snapshot_delete(const nm_str_t *name, int vm_status)
     if (pthread_join(spin_th, NULL) != 0)
         nm_bug(_("%s: cannot join thread"), __func__);
 
-clean_and_out:
-    werase(help_window);
-    nm_init_help_main();
-
 out:
-    wtimeout(action_window, -1);
-    delwin(form_data.form_window);
+    NM_FORM_EXIT();
     nm_vect_free(&snaps, nm_str_vect_free_cb);
     nm_vect_free(&choices, NULL);
-    nm_form_free(form, fields);
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields);
     nm_str_free(&query);
     nm_str_free(&buf);
 }
 
 void nm_vm_snapshot_load(const nm_str_t *name, int vm_status)
 {
-    nm_vect_t snaps = NM_INIT_VECT;
+    nm_form_data_t *form_data = NULL;
+    nm_form_t *form = NULL;
     nm_vect_t choices = NM_INIT_VECT;
     nm_vect_t err = NM_INIT_VECT;
-    nm_form_t *snap_form = NULL;
     nm_str_t query = NM_INIT_STR;
     nm_str_t buf = NM_INIT_STR;
-    nm_form_data_t form_data = NM_INIT_FORM_DATA;
     nm_spinner_data_t sp_data = NM_INIT_SPINNER;
     size_t snaps_count = 0;
     int done = 0;
     pthread_t spin_th;
-    size_t msg_len = mbstowcs(NULL, NM_FORMSTR_SNAP, strlen(NM_FORMSTR_SNAP));
+    size_t msg_len;
 
     nm_str_format(&query, NM_GET_SNAPS_ALL_SQL, name->data);
     nm_db_select(query.data, &snaps);
@@ -217,16 +292,6 @@ void nm_vm_snapshot_load(const nm_str_t *name, int vm_status)
         nm_warn(_(NM_MSG_NO_SNAPS));
         goto out;
     }
-
-    if (nm_form_calc_size(msg_len, 1, &form_data) != NM_OK)
-        goto out;
-
-    werase(action_window);
-    werase(help_window);
-    nm_init_action(_(NM_MSG_SNAP_REV));
-    nm_init_help_edit();
-
-    nm_print_snapshots(&snaps);
 
     snaps_count = snaps.n_memb / 5;
     for (size_t n = 0; n < snaps_count; n++) {
@@ -237,28 +302,40 @@ void nm_vm_snapshot_load(const nm_str_t *name, int vm_status)
             nm_vect_str_len(&snaps, NM_SQL_VMSNAP_NAME + idx_shift) + 1,
             NULL);
     }
-
     nm_vect_end_zero(&choices);
 
-    fields[0] = new_field(1, form_data.form_len, 0, 0, 0, 0);
-    fields[1] = NULL;
+    nm_vm_snapshot_revert_init_windows(NULL);
 
-    set_field_type(fields[0], TYPE_ENUM, choices.data, false, false);
-    set_field_buffer(fields[0], 0, *choices.data);
+    msg_len = mbstowcs(NULL, _(NM_VMSNAP_FORM_SNAP), strlen(_(NM_VMSNAP_FORM_SNAP)));
 
-    mvwaddstr(form_data.form_window, 1, 2, _(NM_FORMSTR_SNAP));
+    form_data = nm_form_data_new(
+        action_window, nm_vm_snapshot_delete_init_windows,
+        msg_len, 1, NM_TRUE
+    );
 
-    snap_form = nm_post_form(form_data.form_window, fields, msg_len + 4, NM_TRUE);
-    curs_set(0);
-    if (nm_draw_form(action_window, snap_form) != NM_OK)
-        goto clean_and_out;
+    if (nm_form_data_update(form_data, 0, 0) != NM_OK)
+        goto out;
 
-    nm_get_field_buf(fields[0], &buf);
-    nm_form_check_data(_(NM_FORMSTR_SNAP), buf, err);
+    fields[0] = nm_field_new(NM_FIELD_LABEL, 0, form_data);
+    fields[1] = nm_field_new(NM_FIELD_EDIT, 0, form_data);
+    fields[2] = NULL;
+
+    set_field_buffer(fields[0], 0, _(NM_VMSNAP_FORM_SNAP));
+    set_field_type(fields[1], TYPE_ENUM, choices.data, false, false);
+    set_field_buffer(fields[1], 0, *choices.data);
+
+    form = nm_form_new(form_data, fields);
+    nm_form_post(form);
+
+    if (nm_form_draw(&form) != NM_OK)
+        goto out;
+
+    nm_get_field_buf(fields[1], &buf);
+    nm_form_check_data(_(NM_VMSNAP_FORM_SNAP), buf, err);
 
     if (nm_print_empty_fields(&err) == NM_ERR) {
         nm_vect_free(&err, NULL);
-        goto clean_and_out;
+        goto out;
     }
 
     sp_data.stop = &done;
@@ -272,14 +349,11 @@ void nm_vm_snapshot_load(const nm_str_t *name, int vm_status)
     if (pthread_join(spin_th, NULL) != 0)
         nm_bug(_("%s: cannot join thread"), __func__);
 
-clean_and_out:
-    werase(help_window);
-    nm_init_help_main();
-
 out:
-    wtimeout(action_window, -1);
-    delwin(form_data.form_window);
-    nm_form_free(snap_form, fields);
+    NM_FORM_EXIT();
+    nm_form_free(form);
+    nm_form_data_free(form_data);
+    nm_fields_free(fields);
     nm_vect_free(&snaps, nm_str_vect_free_cb);
     nm_vect_free(&choices, NULL);
     nm_str_free(&query);
@@ -312,7 +386,7 @@ static void __nm_vm_snapshot_load(const nm_str_t *name, const nm_str_t *snap,
 static void __nm_vm_snapshot_delete(const nm_str_t *name, const nm_str_t *snap,
                                     int vm_status)
 {
-    int rc = NM_ERR;
+    int rc;
 
     if (!vm_status) {
         /* vm is not running, use
@@ -369,7 +443,7 @@ static void __nm_vm_snapshot_delete(const nm_str_t *name, const nm_str_t *snap,
 
 static int nm_vm_snapshot_get_data(const nm_str_t *name, nm_vmsnap_t *data)
 {
-    int rc = NM_OK;
+    int rc;
     nm_str_t query = NM_INIT_STR;
     nm_vect_t names = NM_INIT_VECT;
     nm_vect_t err = NM_INIT_VECT;
@@ -377,8 +451,8 @@ static int nm_vm_snapshot_get_data(const nm_str_t *name, nm_vmsnap_t *data)
     nm_get_field_buf(fields[NM_FLD_VMSNAPNAME], &data->snap_name);
     nm_get_field_buf(fields[NM_FLD_VMLOAD], &data->load);
 
-    nm_form_check_data(_(NM_FORMSTR_NAME), data->snap_name, err);
-    nm_form_check_data(_(NM_FORMSTR_LOAD), data->load, err);
+    nm_form_check_data(_(NM_VMSNAP_FORM_NAME), data->snap_name, err);
+    nm_form_check_data(_(NM_VMSNAP_FORM_LOAD), data->load, err);
 
     if ((rc = nm_print_empty_fields(&err)) == NM_ERR) {
         nm_vect_free(&err, NULL);

--- a/src/nm_vm_snapshot.c
+++ b/src/nm_vm_snapshot.c
@@ -158,6 +158,7 @@ static size_t nm_vm_snapshot_create_labels_setup()
 {
     nm_str_t buf = NM_INIT_STR;
     size_t max_label_len = 0;
+    size_t msg_len = 0;
 
     for (size_t n = 0; n < NM_FLD_COUNT; n++) {
         switch (n) {
@@ -171,8 +172,9 @@ static size_t nm_vm_snapshot_create_labels_setup()
             continue;
         }
 
-        if (buf.len > max_label_len)
-            max_label_len = buf.len;
+        msg_len = mbstowcs(NULL, buf.data, buf.len);
+        if (msg_len > max_label_len)
+            max_label_len = msg_len;
 
         if (fields[n])
             set_field_buffer(fields[n], 0, buf.data);

--- a/src/nm_window.h
+++ b/src/nm_window.h
@@ -6,6 +6,8 @@
 
 #include <signal.h>
 
+static const size_t NM_WINDOW_HEADER_HEIGHT = 3;
+
 void nm_print_vm_info(const nm_str_t *name, const nm_vmctl_data_t *vm, int status);
 void nm_print_iface_info(const nm_vmctl_data_t *vm, size_t idx);
 void nm_print_drive_info(const nm_vect_t *v, size_t idx);
@@ -57,7 +59,6 @@ extern nm_panel_t *action_panel;
 #define NM_MSG_NO_IFACES  "No network configured" NM_MSG_ANY_KEY
 #define NM_MSG_HCPU_KVM   "Host CPU requires KVM enabled" NM_MSG_ANY_KEY
 #define NM_MSG_BAD_CTX    "Contents of field is invalid" NM_MSG_ANY_KEY
-#define NM_MSG_BAD_GROUP  "Group named \"all\" is reserved" NM_MSG_ANY_KEY
 #define NM_MSG_NULL_FLD   "These fields cannot be empty:"
 #define NM_MSG_NAME_BUSY  "This name is already used" NM_MSG_ANY_KEY
 #define NM_MSG_IF_PROP    "Interface properties"
@@ -112,6 +113,7 @@ extern nm_panel_t *action_panel;
 #define NM_NSG_DRV_LIM    "disks limit reached" NM_MSG_ANY_KEY
 #define NM_MSG_DRV_NONE   "No additional disks" NM_MSG_ANY_KEY
 #define NM_MSG_DRV_EDEL   "Cannot delete drive from filesystem" NM_MSG_ANY_KEY
+#define NM_MSG_DRV_SIZE   "Incorrect drive size" NM_MSG_ANY_KEY
 #define NM_MSG_MAC_INVAL  "Invalid mac address" NM_MSG_ANY_KEY
 #define NM_MSF_FWD_INVAL  "Invalid portfwd value, format: tcp|udp::[1-65535]-:[1-65535]" NM_MSG_ANY_KEY
 #define NM_MSG_MAC_USED   "This mac address is already used" NM_MSG_ANY_KEY


### PR DESCRIPTION
Resolves #7. Needs testing before merging into master.

Possible problems:
1. nEMU DB corruption
2. nEMU VM drives corruption
3. Memory leakage (needs to be tested with valgrind, with ncurses built with --disable-leaks flag)
4. Segfaults
5. Incorrect labels in interface