### PR TITLE
ova: fix extract path

### DIFF
--- a/src/nm_ftw.c
+++ b/src/nm_ftw.c
@@ -1,0 +1,167 @@
+#include <nm_core.h>
+#include <nm_ftw.h>
+
+#include <dirent.h>
+
+typedef struct nm_history {
+    struct nm_history *chain;
+    dev_t dev;
+    ino_t ino;
+    int level;
+    int base;
+} nm_history_t;
+
+static int nm_do_ftw(char *path, nm_ftw_cb_t cb, void *ctx, int max_depth,
+        enum nm_ftw_flags flags, nm_history_t *history)
+{
+    size_t path_len = strlen(path);
+    int rc, dfd = -1, err = 0;
+    nm_history_t history_new;
+    enum nm_ftw_type type;
+    size_t base_len;
+    struct stat st;
+    nm_ftw_t ftw;
+
+    if ((flags & NM_FTW_DNFSL) ?
+            lstat(path, &st) : stat(path, &st) < 0) {
+        if (!(flags & NM_FTW_DNFSL) &&
+                errno == ENOENT && lstat(path, &st)) {
+            type = NM_FTW_SLN;
+        } else if (errno != EACCES) {
+            return NM_ERR;
+        } else {
+            type = NM_FTW_NS;
+        }
+    } else if (S_ISDIR(st.st_mode)) {
+        if (flags & NM_FTW_DEPTH) {
+            type = NM_FTW_DP;
+        } else {
+            type = NM_FTW_DIR;
+        }
+    } else if (S_ISLNK(st.st_mode)) {
+        if (flags & NM_FTW_DNFSL) {
+            type = NM_FTW_SL;
+        } else {
+            type = NM_FTW_SLN;
+        }
+    } else {
+        type = NM_FTW_REG;
+    }
+
+    if ((flags & NM_FTW_MOUNT) && history && st.st_dev != history->dev) {
+        return NM_OK;
+    }
+
+    base_len = (path_len && path[path_len - 1] == '/') ?
+        path_len - 1 : path_len;
+
+    history_new.chain = history;
+    history_new.dev = st.st_dev;
+    history_new.ino = st.st_ino;
+    history_new.level = (history) ? history->level + 1 : 0;
+    history_new.base = base_len + 1;
+
+    ftw.level = history_new.level;
+    if (history) {
+        ftw.base = history->base;
+    } else {
+        size_t n = base_len;
+
+        for(; n && path[n] == '/'; n--);
+        for(; n && path[n] != '/'; n--);
+        ftw.base = n;
+    }
+
+    if (type == NM_FTW_DIR || type == NM_FTW_DP) {
+        dfd = open(path, O_RDONLY);
+        err = errno;
+
+        if (dfd < 0 && err == EACCES) {
+            type = NM_FTW_DRE;
+        }
+
+        if (!max_depth) {
+            close(dfd);
+        }
+    }
+
+    if (!(flags & NM_FTW_DEPTH) &&
+            (rc = cb(path, &st, type, &ftw, ctx)) != NM_OK) {
+        return rc;
+    }
+
+    for (; history; history = history->chain) {
+        if (history->dev == st.st_dev && history->ino == st.st_ino) {
+            return NM_OK;
+        }
+    }
+
+    if ((type == NM_FTW_DIR || type == NM_FTW_DP) && max_depth) {
+        DIR *d;
+
+        if (dfd < 0 && err != 0) {
+            errno = err;
+            return NM_ERR;
+        }
+
+        if ((d = fdopendir(dfd))) {
+            struct dirent *de;
+
+            while ((de = readdir(d))) {
+                if (de->d_name[0] == '.' && (!de->d_name[1] ||
+                            (de->d_name[1] == '.' && !de->d_name[2]))) {
+                    continue;
+                }
+
+                if (strlen(de->d_name) >= PATH_MAX - path_len) {
+                    errno = ENAMETOOLONG;
+                    closedir(d);
+                    return NM_ERR;
+                }
+
+                path[base_len] = '/';
+                strcpy(path + base_len + 1, de->d_name);
+
+                if ((rc = nm_do_ftw(path, cb, ctx,
+                                (max_depth == NM_FTW_DEPTH_UNLIM) ?
+                                max_depth : max_depth - 1,
+                                flags, &history_new) != NM_OK)) {
+                    closedir(d);
+                    return rc;
+                }
+            }
+            closedir(d);
+        } else {
+            close(dfd);
+            return NM_ERR;
+        }
+    }
+
+    path[base_len] = '\0';
+
+    if ((flags & NM_FTW_DEPTH) &&
+            (rc = cb(path, &st, type, &ftw, ctx)) != NM_OK) {
+        return rc;
+    }
+
+    return NM_OK;
+}
+
+int nm_ftw(const nm_str_t *path, nm_ftw_cb_t cb,
+        void *ctx, int max_depth, enum nm_ftw_flags flags)
+{
+    int rc = NM_ERR;
+    char path_buf[PATH_MAX + 1] = {0};
+
+    if (path->len > PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return NM_ERR;
+    }
+
+    memcpy(path_buf, path->data, path->len);
+
+    rc = nm_do_ftw(path_buf, cb, ctx, max_depth, flags, NULL);
+
+    return rc;
+}
+/* vim:set ts=4 sw=4: */

--- a/src/nm_ftw.h
+++ b/src/nm_ftw.h
@@ -1,0 +1,45 @@
+#ifndef NM_FTW_H_
+#define NM_FTW_H_
+
+#include <nm_string.h>
+#include <sys/stat.h>
+
+/*
+ * FTW - file tree walk.
+ * This is a clone of the nftw(3) function.
+ * I don't want to use _XOPEN_SOURCE macro.
+ * All logic is taken from musl (src/misc/nftw.c).
+ */
+
+enum nm_ftw_flags {
+    NM_FTW_DNFSL = (1 << 0), /* do not follow symbolic links    */
+    NM_FTW_MOUNT = (1 << 1), /* stay within the same filesystem */
+    NM_FTW_CHDIR = (1 << 2), /* do a chdir(2) to each directory */
+    NM_FTW_DEPTH = (1 << 3)  /* do a post-order traversal       */
+};
+
+enum nm_ftw_type {
+    NM_FTW_REG = 1, /* path is a regular file                                 */
+    NM_FTW_DIR, /* path is a directory                                        */
+    NM_FTW_DRE, /* path is a directory which can't be read                    */
+    NM_FTW_NS,  /* stat(2) call failed on path, which is not a symbolic link  */
+    NM_FTW_SL,  /* path is a symbolic link, and NM_FTW_DNFSL was set in flags */
+    NM_FTW_DP,  /* path is a directory, and FTW_DEPTH was specified in flags  */
+    NM_FTW_SLN  /* path is a symbolic link pointing to a nonexistent file     */
+};
+
+#define NM_FTW_DEPTH_UNLIM -1
+
+typedef struct {
+    int base;
+    int level;
+} nm_ftw_t;
+
+typedef int (*nm_ftw_cb_t)(const char *path, const struct stat *st,
+        enum nm_ftw_type type, nm_ftw_t *ftw, void *ctx);
+
+int nm_ftw(const nm_str_t *path, nm_ftw_cb_t cb, void *ctx,
+        int max_depth, enum nm_ftw_flags flags);
+
+#endif /* NM_FTW_H_ */
+/* vim:set ts=4 sw=4: */

--- a/src/nm_main.c
+++ b/src/nm_main.c
@@ -5,6 +5,7 @@
 #include <nm_cfg_file.h>
 #include <nm_main_loop.h>
 #include <nm_mon_daemon.h>
+#include <nm_ovf_import.h>
 #include <nm_vm_control.h>
 #include <nm_qmp_control.h>
 #include <nm_lan_settings.h>
@@ -44,6 +45,9 @@ int main(int argc, char **argv)
     nm_mon_start();
 #if defined (NM_OS_LINUX)
     nm_lan_create_veth(NM_FALSE);
+#endif
+#if defined (NM_WITH_OVF_SUPPORT)
+    nm_ovf_init();
 #endif
 
     sigemptyset(&sa.sa_mask);

--- a/src/nm_ovf_import.h
+++ b/src/nm_ovf_import.h
@@ -5,6 +5,7 @@
 
 #if defined (NM_WITH_OVF_SUPPORT)
 void nm_ovf_import(void);
+void nm_ovf_init(void);
 #endif
 
 typedef struct {

--- a/src/nm_utils.h
+++ b/src/nm_utils.h
@@ -44,6 +44,7 @@ void nm_exit(int status)
     __attribute__((noreturn));
 int nm_rc();
 
+int nm_cleanup_dir(const nm_str_t *path);
 int nm_mkdir_parent(const nm_str_t *path, mode_t mode);
 
 const char *nm_nemu_path();


### PR DESCRIPTION
We should create temporary directory in cfg.vmdir.
`/tmp` can be small and import will fail.

Close #92