### PR TITLE
Network hotplug feature

### DIFF
--- a/src/nm_database.h
+++ b/src/nm_database.h
@@ -142,6 +142,9 @@ static const char NM_DEL_IFACE_SQL[] = \
 static const char NM_GET_IFACES_MACS[] = \
     "SELECT mac_addr FROM ifaces";
 
+static const char NM_GET_IFACES_NAMES[] = \
+    "SELECT id FROM ifaces WHERE if_name='%s'";
+
 static const char NM_GET_IFMAP_SQL[] = \
     "SELECT vm_name, if_name FROM ifaces WHERE parent_eth='%s' " \
     "OR parent_eth='%s'";

--- a/src/nm_edit_net.c
+++ b/src/nm_edit_net.c
@@ -12,36 +12,6 @@
 static const size_t NM_NET_MACVTAP_NUM = 2;
 #endif
 
-typedef struct {
-    nm_str_t name;
-    nm_str_t drv;
-    nm_str_t maddr;
-    nm_str_t ipv4;
-    nm_str_t netuser;
-    nm_str_t hostfwd;
-    nm_str_t smb;
-#if defined (NM_OS_LINUX)
-    nm_str_t vhost;
-    nm_str_t macvtap;
-    nm_str_t parent_eth;
-#endif
-} nm_iface_t;
-
-#if defined (NM_OS_LINUX)
-#define NM_INIT_NET_IF (nm_iface_t) { \
-                        NM_INIT_STR, NM_INIT_STR, \
-                        NM_INIT_STR, NM_INIT_STR, \
-                        NM_INIT_STR, NM_INIT_STR, \
-                        NM_INIT_STR, NM_INIT_STR, \
-                        NM_INIT_STR, NM_INIT_STR }
-#else
-#define NM_INIT_NET_IF (nm_iface_t) { \
-                        NM_INIT_STR, NM_INIT_STR, \
-                        NM_INIT_STR, NM_INIT_STR, \
-                        NM_INIT_STR, NM_INIT_STR, \
-                        NM_INIT_STR }
-#endif
-
 static const char NM_LC_EDIT_NET_FORM_NDRV[] = "Net driver";
 static const char NM_LC_EDIT_NET_FORM_MADR[] = "Mac address";
 static const char NM_LC_EDIT_NET_FORM_IPV4[] = "IPv4 address";

--- a/src/nm_edit_net.h
+++ b/src/nm_edit_net.h
@@ -3,6 +3,38 @@
 
 #include <nm_string.h>
 
+typedef struct {
+    nm_str_t name;
+    nm_str_t drv;
+    nm_str_t maddr;
+    nm_str_t ipv4;
+    nm_str_t netuser;
+    nm_str_t hostfwd;
+    nm_str_t smb;
+#if defined (NM_OS_LINUX)
+    nm_str_t vhost;
+    nm_str_t macvtap;
+    nm_str_t parent_eth;
+    int tap_fd;
+#endif
+} nm_iface_t;
+
+#if defined (NM_OS_LINUX)
+#define NM_INIT_NET_IF (nm_iface_t) { \
+                        NM_INIT_STR, NM_INIT_STR, \
+                        NM_INIT_STR, NM_INIT_STR, \
+                        NM_INIT_STR, NM_INIT_STR, \
+                        NM_INIT_STR, NM_INIT_STR, \
+                        NM_INIT_STR, NM_INIT_STR, -1 }
+#else
+#define NM_INIT_NET_IF (nm_iface_t) { \
+                        NM_INIT_STR, NM_INIT_STR, \
+                        NM_INIT_STR, NM_INIT_STR, \
+                        NM_INIT_STR, NM_INIT_STR, \
+                        NM_INIT_STR }
+#endif
+
+
 void nm_edit_net(const nm_str_t *name);
 
 #endif /* NM_EDIT_NET_H_ */

--- a/src/nm_edit_net.h
+++ b/src/nm_edit_net.h
@@ -5,6 +5,7 @@
 
 typedef struct {
     nm_str_t name;
+    nm_str_t oldname;
     nm_str_t drv;
     nm_str_t maddr;
     nm_str_t ipv4;
@@ -25,13 +26,14 @@ typedef struct {
                         NM_INIT_STR, NM_INIT_STR, \
                         NM_INIT_STR, NM_INIT_STR, \
                         NM_INIT_STR, NM_INIT_STR, \
-                        NM_INIT_STR, NM_INIT_STR, -1 }
+                        NM_INIT_STR, NM_INIT_STR, \
+                        NM_INIT_STR, -1 }
 #else
 #define NM_INIT_NET_IF (nm_iface_t) { \
                         NM_INIT_STR, NM_INIT_STR, \
                         NM_INIT_STR, NM_INIT_STR, \
                         NM_INIT_STR, NM_INIT_STR, \
-                        NM_INIT_STR }
+                        NM_INIT_STR, NM_INIT_STR }
 #endif
 
 

--- a/src/nm_network.c
+++ b/src/nm_network.c
@@ -40,11 +40,6 @@ enum {
     NM_MACVTAP_PRIVATE = 2
 };
 
-enum {
-    NM_MACVTAP_PRIVATE_MODE = 1,
-    NM_MACVTAP_BRIDGE_MODE = 4
-};
-
 struct iplink_req {
     struct nlmsghdr n;
     struct ifinfomsg i;

--- a/src/nm_network.h
+++ b/src/nm_network.h
@@ -16,6 +16,11 @@ typedef struct {
     uint32_t cidr;
 } nm_net_addr_t;
 
+enum {
+    NM_MACVTAP_PRIVATE_MODE = 1,
+    NM_MACVTAP_BRIDGE_MODE = 4
+};
+
 #define NM_INIT_NETADDR (nm_net_addr_t) { {0}, 0 }
 
 int nm_net_iface_exists(const nm_str_t *name);

--- a/src/nm_qmp_control.h
+++ b/src/nm_qmp_control.h
@@ -2,6 +2,7 @@
 #define NM_QMP_CONTROL_H_
 
 #include <nm_string.h>
+#include <nm_edit_net.h>
 #include <nm_usb_devices.h>
 
 void nm_qmp_vm_shut(const nm_str_t *name);
@@ -14,6 +15,8 @@ int nm_qmp_loadvm(const nm_str_t *name, const nm_str_t *snap);
 int nm_qmp_delvm(const nm_str_t *name, const nm_str_t *snap);
 int nm_qmp_usb_attach(const nm_str_t *name, const nm_usb_data_t *usb);
 int nm_qmp_usb_detach(const nm_str_t *name, const nm_usb_data_t *usb);
+int nm_qmp_nic_attach(const nm_str_t *name, const nm_iface_t *nic);
+int nm_qmp_nic_detach(const nm_str_t *name, const nm_iface_t *nic);
 int nm_qmp_test_socket(const nm_str_t *name);
 void nm_qmp_vm_exec_async(const nm_str_t *name, const char *cmd,
         const char *jobid);

--- a/src/nm_window.c
+++ b/src/nm_window.c
@@ -42,15 +42,15 @@ static void nm_print_help__(const char **keys, const char **values,
     "q:Back", "?:Help"
 #endif
 
-#define X_NM_HELP_GEN                         \
-    X(main, NM_HELP_MSG)                      \
-    X(lan, NM_LAN_MSG)                        \
-    X(edit, "esc:Cancel", "enter:Save")       \
-    X(import, "esc:Cancel", "enter:Import")   \
-    X(install, "esc:Cancel", "enter:Install") \
-    X(iface, "q:Back", "enter:Edit")          \
-    X(clone, "esc:Cancel", "enter:Clone")     \
-    X(export, "esc:Cancel", "enter:Export")   \
+#define X_NM_HELP_GEN                                     \
+    X(main, NM_HELP_MSG)                                  \
+    X(lan, NM_LAN_MSG)                                    \
+    X(edit, "esc:Cancel", "enter:Save")                   \
+    X(import, "esc:Cancel", "enter:Import")               \
+    X(install, "esc:Cancel", "enter:Install")             \
+    X(iface, "q:Back", "a:Add", "r:Remove", "enter:Edit") \
+    X(clone, "esc:Cancel", "enter:Clone")                 \
+    X(export, "esc:Cancel", "enter:Export")               \
     X(delete, "q:Back", "enter:Delete")
 
 #define X(name, ...)                                         \

--- a/src/nm_window.h
+++ b/src/nm_window.h
@@ -136,6 +136,7 @@ extern nm_filter_t nm_filter;
 #define NM_MSG_MAC_INVAL  "Invalid mac address" NM_MSG_ANY_KEY
 #define NM_MSF_FWD_INVAL  "Invalid portfwd value, format: tcp|udp::[1-65535]-:[1-65535]" NM_MSG_ANY_KEY
 #define NM_MSG_MAC_USED   "This mac address is already used" NM_MSG_ANY_KEY
+#define NM_MSG_NIC_USED   "This interface name is already used" NM_MSG_ANY_KEY
 #define NM_MSG_VHOST_ERR  "vhost can be enabled only on virtio-net" NM_MSG_ANY_KEY
 #define NM_MSG_VTAP_NOP   "MacVTap parent interface does not exists" NM_MSG_ANY_KEY
 #define NM_MSG_NAME_DIFF  "Names must be different" NM_MSG_ANY_KEY


### PR DESCRIPTION
In order to manipulate networks hot, it is necessary to
generate a predictable and unique id for netdev and device.

Part of #85