### PR TITLE
import: fix wrong drive virtual size on import

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+v3.2.0 - Future
+------------------------
+    - Bugfix: fix wrong drive virtual size on import
+
 v3.1.0 - 16.10.1022
 ------------------------
     - Feature: network hotplug

--- a/src/nm_add_vm.c
+++ b/src/nm_add_vm.c
@@ -334,17 +334,12 @@ static int nm_add_vm_get_data(nm_vm_t *vm)
     /* Check for free space for importing drive image */
     if (import) {
         off_t size_gb = 0;
-        struct stat img_info;
+        off_t virtual_size, actual_size;
 
-        memset(&img_info, 0, sizeof(img_info));
-
-        if (stat(vm->srcp.data, &img_info) == 0) {
-            size_gb = img_info.st_size / 1024 / 1024 / 1024;
-            nm_str_format(&vm->drive.size, "%ld", size_gb);
-        } else {
-            nm_bug(_("%s: cannot get stat of file: %s"),
-                    __func__, vm->srcp.data);
-        }
+        nm_get_drive_size(&vm->srcp, &virtual_size, &actual_size);
+        size_gb = actual_size / 1073741824;
+        nm_str_format(&vm->drive.size, "%g",
+                (double) virtual_size / 1073741824);
 
         if (size_gb >= nm_hw_disk_free()) {
             curs_set(0);

--- a/src/nm_utils.h
+++ b/src/nm_utils.h
@@ -48,6 +48,8 @@ int nm_cleanup_dir(const nm_str_t *path);
 int nm_mkdir_parent(const nm_str_t *path, mode_t mode);
 
 const char *nm_nemu_path(void);
+void nm_get_drive_size(const nm_str_t *path,
+        off_t *virtual_size, off_t *actual_size);
 
 /*
  * get date and time, format:


### PR DESCRIPTION
qemu-img info --output json <path> is used to get the size.

Close #123