### PR TITLE
sh: fix nonroot setup script

### DIFF
--- a/sh/setup_nemu_nonroot.sh
+++ b/sh/setup_nemu_nonroot.sh
@@ -29,7 +29,7 @@ else
         exit 1
     fi
 
-    QEMU_BIN_PATH=$(grep qemu_bin_path ${USER_DIR}/.nemu.cfg | awk '{ printf "%s\n", $3 }')
+    QEMU_BIN_PATH=$(grep '^qemu_bin_path' ${USER_DIR}/.nemu.cfg | awk '{ printf "%s\n", $3 }')
     if [ -z "$QEMU_BIN_PATH" ]; then
         echo "Couldn't get qemu_bin_path from .nemu.cfg" >&2
         exit 1


### PR DESCRIPTION
The script could take the value from the commented `qemu_bin_path` parameter.