### PR TITLE
snapshots: macos support

### DIFF
--- a/src/nm_main.c
+++ b/src/nm_main.c
@@ -84,9 +84,7 @@ static void nm_process_args(int argc, char **argv)
     const char *optstr = NM_OPT_ARGS;
     nm_str_t vmname = NM_INIT_STR;
     nm_str_t vmnames = NM_INIT_STR;
-#if !defined(NM_OS_DARWIN)
     nm_str_t snapname = NM_INIT_STR;
-#endif
     nm_vect_t vm_list = NM_INIT_VECT;
 
     enum {
@@ -110,13 +108,11 @@ static void nm_process_args(int argc, char **argv)
 #if defined(NM_OS_LINUX)
         { "create-veth", no_argument,       NULL, 'c' },
 #endif
-#if !defined(NM_OS_DARWIN)
         { "snap-save",   required_argument, NULL, OPT_SNAP_SAVE },
         { "snap-load",   required_argument, NULL, OPT_SNAP_LOAD },
         { "snap-del",    required_argument, NULL, OPT_SNAP_DEL  },
         { "snap-list",   required_argument, NULL, OPT_SNAP_LIST },
         { "name",        required_argument, NULL, OPT_SNAP_NAME },
-#endif
         { "start",       required_argument, NULL, 's' },
         { "powerdown",   required_argument, NULL, 'p' },
         { "force-stop",  required_argument, NULL, 'f' },
@@ -283,7 +279,6 @@ static void nm_process_args(int argc, char **argv)
             nm_print_feset();
             nm_cfg_free();
             nm_exit(NM_OK);
-#if !defined(NM_OS_DARWIN)
         case OPT_SNAP_LIST:
             nm_init_core();
             {
@@ -309,7 +304,6 @@ static void nm_process_args(int argc, char **argv)
         case OPT_SNAP_NAME:
             nm_str_format(&snapname, "%s", optarg);
             break;
-#endif
         case 'h':
             printf("%s\n", _("-s, --start      <name> start vm"));
             printf("%s\n", _("-p, --powerdown  <name> powerdown vm"));
@@ -326,7 +320,6 @@ static void nm_process_args(int argc, char **argv)
 #endif
             printf("%s\n", _("-v, --version           show version"));
             printf("%s\n", _("-h, --help              show help"));
-#if !defined(NM_OS_DARWIN)
             printf("%s%s\n", _("    --snap-save <vm-name> --name <snap-name>"),
                     _(" create snapshot"));
             printf("%s%s\n", _("    --snap-load <vm-name> --name <snap-name>"),
@@ -335,7 +328,6 @@ static void nm_process_args(int argc, char **argv)
                     _(" delete snapshot"));
             printf("%s%s\n", _("    --snap-list <vm-name>"),
                     _(" show snapshots"));
-#endif
             nm_exit(NM_OK);
         default:
             nm_exit(NM_ERR);
@@ -343,7 +335,6 @@ static void nm_process_args(int argc, char **argv)
     }
 
     switch (action) {
-#if !defined(NM_OS_DARWIN)
     case ACTION_SNAP_SAVE:
     case ACTION_SNAP_LOAD:
     case ACTION_SNAP_DEL:
@@ -372,7 +363,6 @@ static void nm_process_args(int argc, char **argv)
         nm_str_free(&vmname);
         nm_exit_core();
         break;
-#endif
     default:
         break;
     }

--- a/src/nm_main_loop.c
+++ b/src/nm_main_loop.c
@@ -328,7 +328,7 @@ void nm_start_main_loop(void)
             case NM_KEY_C_UP:
                 nm_viewer(name);
                 break;
-#if !defined(NM_OS_DARWIN)
+
             case NM_KEY_S_UP:
                 if (access(cfg->daemon_pid.data, R_OK) == -1) {
                     nm_warn(_(NM_MSG_NO_DAEMON));
@@ -360,7 +360,6 @@ void nm_start_main_loop(void)
                 }
                 nm_vm_snapshot_delete(name, vm_status);
                 break;
-#endif /* NM_OS_DARWIN */
 
             case NM_KEY_L:
                 if (vm_status) {

--- a/src/nm_pthread_barrier.c
+++ b/src/nm_pthread_barrier.c
@@ -1,0 +1,59 @@
+#include <nm_pthread_barrier.h>
+
+#if defined(NM_OS_DARWIN)
+int pthread_barrier_init(pthread_barrier_t *barrier,
+        const pthread_barrierattr_t *attr, unsigned int count)
+{
+    (void) attr;
+
+    if (!count) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (pthread_mutex_init(&barrier->mutex, 0) < 0) {
+        nm_debug("%s: %s\n", __func__, strerror(errno));
+        return -1;
+    }
+
+    if (pthread_cond_init(&barrier->cond, 0) < 0) {
+        nm_debug("%s: %s\n", __func__, strerror(errno));
+        pthread_mutex_destroy(&barrier->mutex);
+        return -1;
+    }
+
+    barrier->count = count;
+    barrier->cur_count = 0;
+
+    return 0;
+}
+
+int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+    pthread_mutex_lock(&barrier->mutex);
+
+    ++(barrier->cur_count);
+
+    if (barrier->cur_count >= barrier->count) {
+        barrier->cur_count = 0;
+        pthread_cond_broadcast(&barrier->cond);
+        pthread_mutex_unlock(&barrier->mutex);
+
+        return 1;
+    }
+
+    pthread_cond_wait(&barrier->cond, &barrier->mutex);
+    pthread_mutex_unlock(&barrier->mutex);
+
+    return 0;
+}
+
+int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+    pthread_cond_destroy(&barrier->cond);
+    pthread_mutex_destroy(&barrier->mutex);
+
+    return 0;
+}
+#endif /* NM_OS_DARWIN */
+/* vim:set ts=4 sw=4: */

--- a/src/nm_pthread_barrier.h
+++ b/src/nm_pthread_barrier.h
@@ -1,0 +1,27 @@
+#include <nm_core.h>
+
+/*
+ * Macos does not have pthread_barrier.
+ * Let's make them ourselves.
+ */
+
+#if defined(NM_OS_DARWIN)
+#include <pthread.h>
+
+typedef int pthread_barrierattr_t;
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    unsigned int count;
+    unsigned int cur_count;
+} pthread_barrier_t;
+
+int pthread_barrier_init(pthread_barrier_t *barrier,
+        const pthread_barrierattr_t *attr, unsigned int count);
+int pthread_barrier_wait(pthread_barrier_t *barrier);
+int pthread_barrier_destroy(pthread_barrier_t *barrier);
+
+#endif /* NM_OS_DARWIN */
+
+/* vim:set ts=4 sw=4: */

--- a/src/nm_qmp_control.c
+++ b/src/nm_qmp_control.c
@@ -9,7 +9,9 @@
 
 #include <sys/socket.h>
 #include <sys/un.h>
-#if !defined(NM_OS_DARWIN)
+#if defined(NM_OS_DARWIN)
+#include <nm_sysv_queue.h>
+#else
 #include <mqueue.h>
 #endif
 #include <time.h>
@@ -32,7 +34,6 @@ static const char NM_QMP_CMD_VM_STOP[]  = "{\"execute\":\"stop\"}";
 static const char NM_QMP_CMD_VM_CONT[]  = "{\"execute\":\"cont\"}";
 static const char NM_QMP_CMD_JOBS[]     = "{\"execute\":\"query-jobs\"}";
 
-#if !defined(NM_OS_DARWIN)
 static const char NM_QMP_CMD_SAVEVM[]   =
     "{\"execute\":\"snapshot-save\",\"arguments\":{\"job-id\":"
     "\"vmsave-%s-%s\",\"tag\":\"%s\",\"vmstate\":\"%s\",\"devices\":[%s]}}";
@@ -44,7 +45,6 @@ static const char NM_QMP_CMD_LOADVM[]   =
 static const char NM_QMP_CMD_DELVM[]    =
     "{\"execute\":\"snapshot-delete\",\"arguments\":{\"job-id\":"
     "\"vmdel-%s-%s\",\"tag\":\"%s\",\"devices\":[%s]}}";
-#endif
 
 static const char NM_QMP_CMD_USB_ADD[]  =
     "{\"execute\":\"device_add\",\"arguments\":{\"driver\":\"usb-host\","
@@ -110,9 +110,7 @@ static int nm_qmp_talk(int sd, const char *cmd,
                        size_t len, struct timeval *tv);
 static void nm_qmp_talk_async(int sd, const char *cmd,
         size_t len, const char *jobid);
-#if !defined(NM_OS_DARWIN)
 static int nm_qmp_send(const nm_str_t *cmd);
-#endif
 static int nm_qmp_check_answer(const nm_str_t *answer);
 static int nm_qmp_parse(const char *jobid, const nm_str_t *answer);
 static int nm_qmp_check_job(const char *jobid, const nm_str_t *answer);
@@ -154,7 +152,6 @@ void nm_qmp_vm_resume(const nm_str_t *name)
     nm_qmp_vm_exec(name, NM_QMP_CMD_VM_CONT, &tv);
 }
 
-#if !defined(NM_OS_DARWIN)
 int nm_qmp_savevm(const nm_str_t *name, const nm_str_t *snap)
 {
     nm_vect_t drives = NM_INIT_VECT;
@@ -253,7 +250,6 @@ int nm_qmp_delvm(const nm_str_t *name, const nm_str_t *snap)
 
     return rc;
 }
-#endif /* NM_OS_DARWIN */
 
 int nm_qmp_usb_attach(const nm_str_t *name, const nm_usb_data_t *usb)
 {
@@ -418,9 +414,13 @@ out:
     return rc;
 }
 
-#if !defined(NM_OS_DARWIN)
 static int nm_qmp_send(const nm_str_t *cmd)
 {
+#if defined(NM_OS_DARWIN)
+    if (!nm_sysv_queue_send(cmd)) {
+        return NM_ERR;
+    }
+#else
     mqd_t mq;
 
     if ((mq = mq_open(NM_MQ_PATH, O_WRONLY | O_CREAT | O_NONBLOCK,
@@ -433,10 +433,9 @@ static int nm_qmp_send(const nm_str_t *cmd)
     }
 
     mq_close(mq);
-
+#endif /* NM_OS_DARWIN */
     return NM_OK;
 }
-#endif
 
 #if defined (NM_OS_LINUX)
 /*

--- a/src/nm_sysv_queue.c
+++ b/src/nm_sysv_queue.c
@@ -1,0 +1,113 @@
+#include <nm_core.h>
+
+#if defined(NM_OS_DARWIN)
+#include <sys/ipc.h>
+#include <sys/msg.h>
+
+#define NM_SYSV_MAX_MSGSIZE 2048
+#define NM_SYSV_QUEUE_PATH  "/tmp/nemu_sysv_queue"
+#define NM_SYSV_PROJ_ID     'N'
+#define NM_SYSV_MSG_TYPE    1
+
+typedef struct {
+    long mtype;
+    char mtext[NM_SYSV_MAX_MSGSIZE];
+} nm_sysv_msg_t;
+
+static int nm_sysv_create_id_file(void)
+{
+    struct stat info;
+
+    memset(&info, 0, sizeof(info));
+    if (stat(NM_SYSV_QUEUE_PATH, &info) == 0) {
+        return NM_OK;
+    }
+
+    if (open(NM_SYSV_QUEUE_PATH, O_CREAT, S_IRUSR) == -1) {
+        nm_debug("%s: cannot create %s: %s\n",
+                __func__, NM_SYSV_QUEUE_PATH, strerror(errno));
+        return NM_ERR;
+    }
+
+    return NM_OK;
+}
+
+static int nm_sysv_queue_open(void)
+{
+    key_t key;
+    int queue_id = -1;
+    struct msqid_ds id;
+
+    if (nm_sysv_create_id_file() == NM_ERR) {
+        goto out;
+    }
+
+    if ((key = ftok(NM_SYSV_QUEUE_PATH, NM_SYSV_PROJ_ID)) == -1) {
+        nm_debug("%s: ftok: %s\n", __func__, strerror(errno));
+        goto out;
+    }
+
+    queue_id = msgget(key, IPC_CREAT | 0600);
+    if (msgctl(queue_id, IPC_STAT, &id) == -1) {
+        nm_debug("%s: msgctl: %s\n", __func__, strerror(errno));
+    }
+
+out:
+    return queue_id;
+}
+
+bool nm_sysv_queue_send(const nm_str_t *msg)
+{
+    int queue_id;
+    nm_sysv_msg_t qmsg;
+
+    memset(&qmsg, 0, sizeof(qmsg));
+
+    if ((queue_id = nm_sysv_queue_open()) == -1) {
+        nm_debug("%s: %s\n", __func__, strerror(errno));
+        return false;
+    }
+
+    if (msg->len > NM_SYSV_MAX_MSGSIZE) {
+        return false;
+    }
+
+    qmsg.mtype = NM_SYSV_MSG_TYPE;
+    memcpy(qmsg.mtext, msg->data, msg->len);
+
+    if (msgsnd(queue_id, &qmsg, sizeof(qmsg.mtext), IPC_NOWAIT) == -1) {
+        nm_debug("%s: cannot send msg: %s\n", __func__, strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+bool nm_sysv_queue_recv(nm_str_t *msg)
+{
+    int queue_id;
+    nm_sysv_msg_t qmsg;
+
+    memset(&qmsg, 0, sizeof(qmsg));
+
+    if ((queue_id = nm_sysv_queue_open()) == -1) {
+        nm_debug("%s: %s\n", __func__, strerror(errno));
+        return false;
+    }
+
+    if (msgrcv(queue_id, &qmsg, sizeof(qmsg.mtext),
+                NM_SYSV_MSG_TYPE, IPC_NOWAIT) == -1) {
+        if (errno != ENOMSG) {
+            nm_debug("%s: %s\n", __func__, strerror(errno));
+        }
+        return false;
+    }
+
+    nm_str_format(msg, "%s", qmsg.mtext);
+
+    return true;
+}
+
+#endif /* NM_OS_DARWIN */
+
+/* vim:set ts=4 sw=4: */

--- a/src/nm_sysv_queue.h
+++ b/src/nm_sysv_queue.h
@@ -1,0 +1,10 @@
+#include <nm_core.h>
+
+#if defined(NM_OS_DARWIN)
+
+bool nm_sysv_queue_send(const nm_str_t *msg);
+bool nm_sysv_queue_recv(nm_str_t *msg);
+
+#endif /* NM_OS_DARWIN */
+
+/* vim:set ts=4 sw=4: */

--- a/src/nm_vm_control.c
+++ b/src/nm_vm_control.c
@@ -100,12 +100,10 @@ void nm_vmctl_start(const nm_str_t *name, int flags)
             }
 
             /* load snapshot and resume vm after suspend */
-#if !defined(NM_OS_DARWIN)
             if (flags & NM_VMCTL_CONT) {
                 nm_qmp_loadvm(name, &snap);
                 nm_qmp_vm_resume(name);
             }
-#endif
         }
     }
 

--- a/src/nm_vm_snapshot.c
+++ b/src/nm_vm_snapshot.c
@@ -9,8 +9,6 @@
 #include <nm_qmp_control.h>
 #include <nm_vm_snapshot.h>
 
-#if !defined(NM_OS_DARWIN)
-
 typedef struct {
     nm_str_t snap_name;
     nm_str_t load;
@@ -665,5 +663,4 @@ static void nm_vm_snapshot_to_db(const nm_str_t *name, const nm_vmsnap_t *data)
     nm_str_free(&query);
 }
 
-#endif /* NM_OS_DARWIN */
 /* vim:set ts=4 sw=4: */


### PR DESCRIPTION
nEMU snapshots uses POSIX queue. MacOS does not support it. this patch uses System V message queues for MacOS build.

Close #153