### PR TITLE
import: fix comma in capacity

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 unreleased
 ------------------------
     - Feature: image format type support: qcow2 and raw
+    - Bugfix: fix import on some locales
 
 v3.3.1 - 19.02.2024
 ------------------------

--- a/src/nm_database.h
+++ b/src/nm_database.h
@@ -310,13 +310,13 @@ static const char NM_SQL_DRIVES_INSERT_NEW[] =
     "INSERT INTO drives(vm_id, drive_name, drive_drv, "
     "capacity, boot, discard, format) "
     "VALUES((SELECT id FROM vms WHERE name='%s'), "
-    "'%s_a.img', '%s', %s, %s, %s, '%s')";
+    "'%s_a.img', '%s', '%s', %s, %s, '%s')";
 
 static const char NM_SQL_DRIVES_INSERT_ADD[] =
     "INSERT INTO drives(vm_id, drive_name, drive_drv, "
     "capacity, boot, discard, format) "
     "VALUES((SELECT id FROM vms WHERE name='%s'), "
-    "'%s_%c.img', '%s', %s, 0, %s, '%s')";
+    "'%s_%c.img', '%s', '%s', 0, %s, '%s')";
 
 static const char NM_SQL_DRIVES_INSERT_IMPORTED[] =
     "INSERT INTO drives(vm_id, drive_name, drive_drv, "


### PR DESCRIPTION
This patch fixes error while importing image:
`nm_db_edit: database error: 8 values for 7 columns`

In some locales, there may be a comma instead of a period in fractional numbers, which breaks the SQL query.

Closes #181