### PR TITLE
ci: use gh checkout action

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -18,7 +18,7 @@ jobs:
           git clone https://github.com/nemuTUI/nemu
           cd nemu
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git checkout ${{ github.head_ref }}
+            git checkout ${{ github.event.pull_request.head.sha }}
           fi
           mkdir build && cd build
           cmake ../ -DNM_WITH_DBUS=ON -DNM_WITH_REMOTE=ON


### PR DESCRIPTION
Now FreeBSD workflow fails if PR from forked repo: error: pathspec 'remote_branch' did not match any file(s) known to git