### PR TITLE
preview: pass the path to the file

### DIFF
--- a/src/nm_cfg_file.c
+++ b/src/nm_cfg_file.c
@@ -390,6 +390,7 @@ void nm_cfg_init(bool bypass_cfg)
                 &cfg.preview.path) != NM_OK) {
         nm_str_alloc_text(&cfg.preview.path, NM_DEFAULT_PNG);
     }
+    cfg.preview.b64_path = nm_64_encode(&cfg.preview.path);
 
 #if defined (NM_WITH_REMOTE)
     nm_str_trunc(&tmp_buf, 0);
@@ -465,6 +466,7 @@ void nm_cfg_free(void)
     nm_str_free(&cfg.daemon_pid);
     nm_str_free(&cfg.qemu_bin_path);
     nm_str_free(&cfg.preview.path);
+    free(cfg.preview.b64_path);
     nm_vect_free(&cfg.qemu_targets, NULL);
 #if defined (NM_WITH_REMOTE)
     nm_str_free(&cfg.api_cert_path);

--- a/src/nm_cfg_file.h
+++ b/src/nm_cfg_file.h
@@ -28,6 +28,7 @@ typedef struct {
 
 typedef struct {
     nm_str_t path;
+    char *b64_path;
     uint32_t enabled:1;
     uint32_t scale:1;
 } nm_preview_t;

--- a/src/nm_utils.c
+++ b/src/nm_utils.c
@@ -592,33 +592,33 @@ static const char
 b64_chars[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-char *nm_64_encode(const uint8_t *src, size_t src_len)
+char *nm_64_encode(const nm_str_t *src)
 {
     size_t res_len;
     char *res;
 
-    res_len = 4 * ((src_len + 2) / 3);
+    res_len = 4 * ((src->len + 2) / 3);
     res = nm_calloc(1, res_len + 1);
     if (!res) {
         return NULL;
     }
 
-    for (size_t i = 0, j = 0; i < src_len; i += 3, j += 4) {
-        size_t a = i < src_len ? src[i] : 0;
-        size_t b = i + 1 < src_len ? src[i + 1] : 0;
-        size_t c = i + 2 < src_len ? src[i + 2] : 0;
+    for (size_t i = 0, j = 0; i < src->len; i += 3, j += 4) {
+        size_t a = i < src->len ? src->data[i] : 0;
+        size_t b = i + 1 < src->len ? src->data[i + 1] : 0;
+        size_t c = i + 2 < src->len ? src->data[i + 2] : 0;
         size_t abc = (a << 0x10) + (b << 0x8) + c;
 
         res[j] = b64_chars[(abc >> 18) & 0x3F];
         res[j + 1] = b64_chars[(abc >> 12) & 0x3F];
 
-        if (i + 1 < src_len) {
+        if (i + 1 < src->len) {
             res[j + 2] = b64_chars[(abc >> 6) & 0x3F];
         } else {
             res[j + 2] = '=';
         }
 
-        if (i + 2 < src_len) {
+        if (i + 2 < src->len) {
             res[j + 3] = b64_chars[abc & 0x3F];
         } else {
             res[j + 3] = '=';

--- a/src/nm_utils.h
+++ b/src/nm_utils.h
@@ -67,7 +67,7 @@ void nm_gen_rand_str(nm_str_t *res, size_t len);
 void nm_gen_uid(nm_str_t *res);
 
 /* Caller must free the return value. */
-char *nm_64_encode(const uint8_t *src, size_t src_len);
+char *nm_64_encode(const nm_str_t *src);
 
 #endif /* NM_UTILS_H_ */
 /* vim:set ts=4 sw=4: */

--- a/src/nm_window.c
+++ b/src/nm_window.c
@@ -664,33 +664,27 @@ nm_print_vm_info(const nm_str_t *name, const nm_vmctl_data_t *vm, int status)
             (void) pid_num;
 #endif
             if (nm_cfg_get()->preview.enabled) {
-                char *b64;
-                nm_file_map_t png = NM_INIT_FILE;
                 size_t side_cols, NM_UNUSED side_rows;
+                const nm_str_t *png_path = &nm_cfg_get()->preview.path;
 
-                nm_qmp_take_screenshot(name, &nm_cfg_get()->preview.path);
-                png.name = &nm_cfg_get()->preview.path;
-                nm_map_file(&png);
-                b64 = nm_64_encode(png.mp, png.size);
-
+                nm_qmp_take_screenshot(name, png_path);
                 getmaxyx(side_window, side_rows, side_cols);
 
                 if (nm_cfg_get()->preview.scale) {
                     nm_str_format(&buf,
-                            "\x1b_Gi=20509,q=2,a=T,C=1,c=%zu,r=%zu,f=100;%s"
+                            "\x1b_Gi=20509,q=2,a=T,C=1,c=%zu,r=%zu,t=f,f=100;%s"
                             "\x1b\x5c",
-                            cols - 4, rows - y - 2, b64);
+                            cols - 4, rows - y - 2,
+                            nm_cfg_get()->preview.b64_path);
                 } else {
                     nm_str_format(&buf,
-                            "\x1b_Gi=20509,q=2,a=T,C=1,r=%zu,f=100;%s\x1b\x5c",
-                            rows - y - 3, b64);
+                            "\x1b_Gi=20509,q=2,a=T,C=1,r=%zu,t=f,f=100;%s"
+                            "\x1b\x5c",
+                            rows - y - 3, nm_cfg_get()->preview.b64_path);
                 }
                 mvcur(42, 42, y + 2, side_cols + 2);
                 printf("%s", buf.data);
                 fflush(stdout);
-
-                nm_unmap_file(&png);
-                free(b64);
             }
         } else { /* clear PID file info and cpu usage data */
             if (y < (rows - 2)) {


### PR DESCRIPTION
    Passing file contents to the renderer instead of a path
    is extremely unwise. Encoding the entire content each time,
    even though you already have a file output from qemu, is at
    the very least very unreasonable. The author (me) was probably
    not in his right mind when writing this code.