### PR TITLE
ci: fall back to macos-14

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   macosx_build:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - name: Get nEMU sources


### PR DESCRIPTION
Fix `ld: symbol(s) not found for architecture arm64` error on macos-latest.