### PR TITLE
cfg: add enable_stdout parameter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,11 @@ unreleased
     - Feature: configurable refresh timeout for properties window
         Parameter `refresh_timeout` in `main` section
     - Feature: image format type support: qcow2 and raw
+    - Feature: add `background_mode` to config file.
+        background_mode = 0 enables stdout and stderr and
+        also does not run the application in the background.
+        This parameter was added to allow embedding
+        spice-kitten into the UI.
     - Bugfix: fix import on some locales
 
 v3.3.1 - 19.02.2024

--- a/nemu.cfg.sample
+++ b/nemu.cfg.sample
@@ -37,6 +37,9 @@ db = /home/user/.nemu.db
 # default protocol (1 - spice, 0 - vnc)
 spice_default = 1
 
+# run the application in the background.
+background_mode = 1
+
 # vnc client path.
 vnc_bin = /usr/bin/vncviewer
 

--- a/src/nm_cfg_file.c
+++ b/src/nm_cfg_file.c
@@ -54,6 +54,7 @@ static const char NM_INI_P_ERR[]        = "err_color";
 static const char NM_INI_P_CS[]         = "cursor_style";
 static const char NM_INI_P_DEBUG_PATH[] = "debug_path";
 static const char NM_INI_P_PROT[]       = "spice_default";
+static const char NM_INI_P_BGMD[]       = "background_mode";
 static const char NM_INI_P_VBIN[]       = "vnc_bin";
 static const char NM_INI_P_VARG[]       = "vnc_args";
 static const char NM_INI_P_SBIN[]       = "spice_bin";
@@ -209,6 +210,14 @@ void nm_cfg_init(bool bypass_cfg)
 
     nm_get_param(ini, NM_INI_S_VIEW, NM_INI_P_PROT, &tmp_buf, NULL);
     cfg.spice_default = !!nm_str_stoui(&tmp_buf, 10);
+    nm_str_trunc(&tmp_buf, 0);
+
+    if (nm_get_opt_param(ini, NM_INI_S_VIEW, NM_INI_P_BGMD,
+                &tmp_buf) == NM_OK) {
+        cfg.background_mode = !!nm_str_stoui(&tmp_buf, 10);
+    } else {
+        cfg.background_mode = 1;
+    }
     nm_str_trunc(&tmp_buf, 0);
 
     /* Get the VNC listen value */
@@ -652,6 +661,8 @@ static void nm_generate_cfg(const char *home, const nm_str_t *cfg_path)
             fprintf(cfg_file, "[viewer]\n");
             fprintf(cfg_file, "# default protocol (1 - spice, 0 - vnc)"
                     "\nspice_default = 1\n\n");
+            fprintf(cfg_file, "# run the application in the background."
+                    "\nbackground_mode = 1\n\n");
             fprintf(cfg_file, "# vnc client path.\nvnc_bin = %s\n\n",
                     vnc_bin.data);
             fprintf(cfg_file, "# vnc client args (%%t - title, %%p - port)"

--- a/src/nm_cfg_file.h
+++ b/src/nm_cfg_file.h
@@ -75,6 +75,7 @@ typedef struct {
     uint32_t hl_is_set:1;
     uint32_t err_is_set:1;
     uint32_t debug:1;
+    uint32_t background_mode:1;
 } nm_cfg_t;
 
 void nm_cfg_init(bool bypass_cfg);

--- a/src/nm_vm_control.c
+++ b/src/nm_vm_control.c
@@ -1401,7 +1401,9 @@ static void nm_vmctl_gen_viewer(const nm_str_t *name, uint32_t port,
         nm_str_add_text_part(cmd, argsp, args->len - total - 2);
     }
 
-    nm_str_append_format(cmd, " > /dev/null 2>&1 &");
+    if (cfg->background_mode) {
+        nm_str_append_format(cmd, " > /dev/null 2>&1 &");
+    }
     nm_debug("viewer cmd:\"%s\"\n", cmd->data);
 out:
     nm_str_free(&buf);


### PR DESCRIPTION
This parameter enables stdout and stderr and
also does not run the application in the background. This parameter was added to allow embedding
spice-kitten into the UI.