### PR TITLE
search: fix group filter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+unreleased
+------------------------
+    - Bugfix: the group filter `g:group_name` was not
+        working at all as intended.
+
 v3.4.0 - 22.10.2025
 ------------------------
     - Feature: VM preview

--- a/src/nm_main_loop.c
+++ b/src/nm_main_loop.c
@@ -664,7 +664,7 @@ static int nm_filter_check(const nm_str_t *input)
         return NM_ERR;
     }
 
-    if (input->data[0] != 'g' && input->data[1] != ':') {
+    if (input->data[0] != 'g' || input->data[1] != ':') {
         return NM_ERR;
     }
 


### PR DESCRIPTION
The group filter: (g:group_name) was not working at all as intended due to an inexplicably stupid logical error.